### PR TITLE
RIA-7378 - preventing application startup if secrets can't be found

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -24,6 +24,7 @@ def secrets = [
     secret('docmosis-enabled', 'IA_DOCMOSIS_ENABLED'),
     secret('em-stitching-enabled', 'IA_EM_STITCHING_ENABLED'),
     secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
+    secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET'),
 
     secret('test-caseofficer-username', 'TEST_CASEOFFICER_USERNAME'),
     secret('test-caseofficer-password', 'TEST_CASEOFFICER_PASSWORD'),

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -30,6 +30,7 @@ def secrets = [
     secret('docmosis-enabled', 'IA_DOCMOSIS_ENABLED'),
     secret('em-stitching-enabled', 'IA_EM_STITCHING_ENABLED'),
     secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
+    secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET')
 
   ]
 ]

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -22,6 +22,7 @@ def secrets = [
     secret('s2s-microservice', 'IA_S2S_MICROSERVICE'),
     secret('prof-ref-data-url', 'PROF_REF_DATA_URL'),
     secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
+    secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET'),
 
     secret('test-caseofficer-username', 'TEST_CASEOFFICER_USERNAME'),
     secret('test-caseofficer-password', 'TEST_CASEOFFICER_PASSWORD'),

--- a/charts/ia-hearings-api/Chart.yaml
+++ b/charts/ia-hearings-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for ia-hearings-api App
 name: ia-hearings-api
 home: https://github.com/hmcts/ia-hearings-api
-version: 0.0.4
+version: 0.0.5
 maintainers:
   - name: HMCTS ia team
     email: ImmigrationandAsylum@HMCTS.NET

--- a/charts/ia-hearings-api/values.yaml
+++ b/charts/ia-hearings-api/values.yaml
@@ -41,3 +41,5 @@ java:
           alias: LAUNCH_DARKLY_SDK_KEY
         - name: AppInsightsInstrumentationKey
           alias: azure.application-insights.instrumentation-key
+        - name: ia-config-validator-secret
+          alias: IA_CONFIG_VALIDATOR_SECRET

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -93,5 +93,6 @@
     <cve>CVE-2023-33201</cve>
     <cve>CVE-2023-2976</cve>
     <cve>CVE-2023-35116</cve>
+    <cve>CVE-2023-34034</cve>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/ConfigValidatorAppListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/ConfigValidatorAppListener.java
@@ -10,6 +10,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+
 @Component
 @Slf4j
 @Getter
@@ -34,7 +35,8 @@ public class ConfigValidatorAppListener implements ApplicationListener<ContextRe
         log.info("{} value: {}", CLUSTER_NAME, clusterName);
         if (StringUtils.isBlank(clusterName)) {
             log.warn("{} is null or empty. Skipping this check. This is allowed on a developer's local environment "
-                + "but not on a cluster. If you are in a cluster, this warning is going to be a problem.", CLUSTER_NAME);
+                + "but not on a cluster. If you are in a cluster, this warning is going to be a problem.",
+                     CLUSTER_NAME);
             return;
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/ConfigValidatorAppListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/ConfigValidatorAppListener.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.reform.iahearingsapi.infrastructure;
+
+import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.StringUtils;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+@Component
+@Slf4j
+@Getter
+@Setter
+public class ConfigValidatorAppListener implements ApplicationListener<ContextRefreshedEvent> {
+
+    protected static final String CLUSTER_NAME = "CLUSTER_NAME";
+
+    @Autowired
+    private Environment environment;
+
+    @Value("${ia.config.validator.secret}")
+    private String iaConfigValidatorSecret;
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        breakOnMissingIaConfigValidatorSecret();
+    }
+
+    void breakOnMissingIaConfigValidatorSecret() {
+        String clusterName = environment.getProperty(CLUSTER_NAME);
+        log.info("{} value: {}", CLUSTER_NAME, clusterName);
+        if (StringUtils.isBlank(clusterName)) {
+            log.warn("{} is null or empty. Skipping this check. This is allowed on a developer's local environment "
+                + "but not on a cluster. If you are in a cluster, this warning is going to be a problem.", CLUSTER_NAME);
+            return;
+        }
+
+        if (StringUtils.isBlank(iaConfigValidatorSecret)) {
+            throw new IllegalArgumentException("ia.config.validator.secret is null or empty."
+                + " This is not allowed and it will break production. This is a secret value stored in a vault"
+                + " (unless running locally). Check application.yaml for further information.");
+        }
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -137,3 +137,8 @@ core_case_data_api_assignments_url: ${CCD_URL:http://127.0.0.1:4452}
 assign_case_access_api_url: ${AAC_URL:http://127.0.0.1:4454}
 core_case_data_api_assignments_path: "/case-users"
 assign_case_access_api_assignments_path: "/case-assignments"
+
+ia:
+  config:
+    validator:
+      secret: ${IA_CONFIG_VALIDATOR_SECRET:}

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/ConfigValidatorAppListenerTest.java
@@ -76,8 +76,9 @@ class ConfigValidatorAppListenerTest {
         verify(env).getProperty(CLUSTER_NAME);
     }
 
+    // suppressing SonarLint warning on assertions as it's ok for this test not to have any
     @Test
-    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    @SuppressWarnings("java:S2699")
     void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateLocal() {
         // Given
         configValidatorAppListener.setIaConfigValidatorSecret("secret");
@@ -91,8 +92,9 @@ class ConfigValidatorAppListenerTest {
         // I run successfully till the end
     }
 
+    // suppressing SonarLint warning on assertions as it's ok for this test not to have any
     @Test
-    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    @SuppressWarnings("java:S2699")
     void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateCluster() {
         // Given
         configValidatorAppListener.setIaConfigValidatorSecret("secret");

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/ConfigValidatorAppListenerTest.java
@@ -1,0 +1,109 @@
+package uk.gov.hmcts.reform.iahearingsapi.infrastructure;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iahearingsapi.infrastructure.ConfigValidatorAppListener.CLUSTER_NAME;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigValidatorAppListenerTest {
+
+    @Mock
+    private Environment env;
+
+    private ConfigValidatorAppListener configValidatorAppListener;
+
+    @BeforeEach
+    public void setup() {
+        configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setEnvironment(env);
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699")
+    void throwsExceptionWhenIaConfigValidatorSecretIsNullSimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret(null);
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsNullSimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret(null);
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmptySimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmptySimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+        // I run successfully till the end
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+        // I run successfully till the end
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7383


### Change description ###
Adding ia.config.validator.secret to application.yaml + ConfigValidatorAppListener to check to see if secrets are being applied by azure.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
