### PR TITLE
RIA-7860 Screen flow update + LegalRepOrgDetailsMapper name bug

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LegalRepOrgDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LegalRepOrgDetailsMapper.java
@@ -13,7 +13,8 @@ public class LegalRepOrgDetailsMapper {
 
     public PartyDetailsModel map(AsylumCase asylumCase, CaseDataToServiceHearingValuesMapper caseDataMapper) {
 
-        String legalRepCompanyName = asylumCase.read(LEGAL_REP_COMPANY_NAME, String.class).orElse(null);
+        String legalRepCompanyName = asylumCase.read(LEGAL_REP_COMPANY_NAME, String.class).orElse("n/a");
+        // TODO: make sure legal rep company name exists (organisationDetailsModel.name cannot be empty)
 
         return PartyDetailsModel.builder()
             .partyID(caseDataMapper.getLegalRepOrgPartyId(asylumCase))

--- a/src/main/resources/screenFlowMinusPanel.json
+++ b/src/main/resources/screenFlowMinusPanel.json
@@ -60,6 +60,14 @@
       "screenName": "hearing-judge",
       "navigation": [
         {
+          "resultValue": "hearing-timing"
+        }
+      ]
+    },
+    {
+      "screenName": "hearing-timing",
+      "navigation": [
+        {
           "resultValue": "hearing-link"
         }
       ]

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LegalRepOrgDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LegalRepOrgDetailsMapperTest.java
@@ -2,7 +2,9 @@ package uk.gov.hmcts.reform.iahearingsapi.domain.mappers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.*;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -14,6 +16,8 @@ import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyDetailsModel;
 @ExtendWith(MockitoExtension.class)
 class LegalRepOrgDetailsMapperTest {
 
+    private static final String COMPANY_NAME = "companyName";
+
     @Mock
     private AsylumCase asylumCase;
     @Mock
@@ -22,6 +26,7 @@ class LegalRepOrgDetailsMapperTest {
     @Test
     void should_map_correctly() {
 
+        when(asylumCase.read(LEGAL_REP_COMPANY_NAME, String.class)).thenReturn(Optional.of(COMPANY_NAME));
         when(caseDataMapper.getLegalRepOrgPartyId(asylumCase)).thenReturn("partyId");
 
         PartyDetailsModel expected = PartyDetailsModel.builder()
@@ -30,8 +35,9 @@ class LegalRepOrgDetailsMapperTest {
             .partyRole("LGRP")
             .organisationDetails(
                 OrganisationDetailsModel.builder()
-                            .organisationType("ORG")
-                            .build())
+                    .name(COMPANY_NAME)
+                    .organisationType("ORG")
+                    .build())
             .build();
 
         assertEquals(expected, new LegalRepOrgDetailsMapper().map(asylumCase, caseDataMapper));


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7860](https://tools.hmcts.net/jira/browse/RIA-7860)


### Change description ###
- Added default value of `legalRepCompanyName` if not present so that the call to cft-hearing-service doesn't fail
- Reintroduced the timings screen that was left out initially


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
