### PR TITLE
RIA-7617 Fix language and adjustment fields inside partyDetails

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,4 @@
 {
-  "enabledManagers": ["helm-requirements","gradle-wrapper"],
-  "labels": ["dependencies"],
-  "helm-requirements":
-  {
-    "fileMatch": ["\\Chart.yaml$"],
-    "aliases": {
-      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
-    }
-  }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>hmcts/.github:renovate-config", "local>hmcts/.github//renovate/automerge-all"]
 }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapper.java
@@ -13,6 +13,8 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.GrantedRefusedTy
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.SingleSexType.MALE;
 
 import java.util.Collections;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition;
@@ -21,7 +23,10 @@ import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyDetailsModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyType;
 
 @Component
+@AllArgsConstructor
 public class AppellantDetailsMapper {
+
+    private LanguageAndAdjustmentsMapper languageAndAdjustmentsMapper;
 
     public PartyDetailsModel map(
         AsylumCase asylumCase,
@@ -47,7 +52,7 @@ public class AppellantDetailsMapper {
             singleSexCourtResponse.append(";");
         }
 
-        return PartyDetailsModel.builder()
+        PartyDetailsModel appellantPartyDetailsModel = PartyDetailsModel.builder()
             .partyID(caseDataMapper.getAppellantPartyId(asylumCase))
             .partyType(PartyType.IND.getPartyType())
             .individualDetails(
@@ -69,5 +74,7 @@ public class AppellantDetailsMapper {
             .unavailabilityDOW(Collections.emptyList())
             .unavailabilityRanges(caseDataMapper.getUnavailabilityRanges(asylumCase))
             .build();
+
+        return languageAndAdjustmentsMapper.processPartyCaseFlags(asylumCase, appellantPartyDetailsModel);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapper.java
@@ -14,7 +14,6 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.SingleSexType.MA
 
 import java.util.Collections;
 import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition;

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProvider.java
@@ -4,9 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static net.minidev.json.parser.JSONParser.DEFAULT_PERMISSIVE_MODE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HMCTS_CASE_NAME_INTERNAL;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_LENGTH;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper.INTERPRETER_LANGUAGE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper.OTHER_REASONABLE_ADJUSTMENTS_DETAILS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper.REASONABLE_ADJUSTMENTS;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -15,7 +12,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProvider.java
@@ -78,9 +78,6 @@ public class ServiceHearingValuesProvider {
             .orElseThrow(() ->
                 new RequiredFieldMissingException("List case hearing length is a required field"));
 
-        Map<String, List<String>> languageAndReasonableAdjustments = languageAndAdjustmentsMapper
-            .getLanguageAndAdjustmentsFields(asylumCase);
-
         List<PartyDetailsModel> partyDetails = getPartyDetails(asylumCase);
 
         return ServiceHearingValuesModel.builder()
@@ -128,10 +125,6 @@ public class ServiceHearingValuesProvider {
             .hearingChannels(caseDataMapper
                 .getHearingChannels(asylumCase))
             .hearingLevelParticipantAttendance(Collections.emptyList())
-            .interpreterLanguage(languageAndReasonableAdjustments.get(INTERPRETER_LANGUAGE).get(0))
-            .reasonableAdjustments(languageAndReasonableAdjustments.get(REASONABLE_ADJUSTMENTS))
-            .otherReasonableAdjustmentsDetails(languageAndReasonableAdjustments
-                .get(OTHER_REASONABLE_ADJUSTMENTS_DETAILS))
             .build();
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapperTest.java
@@ -29,6 +29,8 @@ class AppellantDetailsMapperTest {
     private CaseFlagsToServiceHearingValuesMapper caseFlagsMapper;
     @Mock
     private CaseDataToServiceHearingValuesMapper caseDataMapper;
+    @Mock
+    private LanguageAndAdjustmentsMapper languageAndAdjustmentsMapper;
 
     @BeforeEach
     void setup() {
@@ -54,8 +56,10 @@ class AppellantDetailsMapperTest {
             .otherReasonableAdjustmentDetails("")
             .build();
         PartyDetailsModel expected = getPartyDetailsModelForAppellant(individualDetails);
+        when(languageAndAdjustmentsMapper.processPartyCaseFlags(asylumCase, expected)).thenReturn(expected);
 
-        assertEquals(expected, new AppellantDetailsMapper().map(asylumCase, caseFlagsMapper, caseDataMapper));
+        assertEquals(expected, new AppellantDetailsMapper(languageAndAdjustmentsMapper)
+            .map(asylumCase, caseFlagsMapper, caseDataMapper));
     }
 
     @Test
@@ -72,8 +76,10 @@ class AppellantDetailsMapperTest {
             .otherReasonableAdjustmentDetails("Single sex court: Female;")
             .build();
         PartyDetailsModel expected = getPartyDetailsModelForAppellant(individualDetails);
+        when(languageAndAdjustmentsMapper.processPartyCaseFlags(asylumCase, expected)).thenReturn(expected);
 
-        assertEquals(expected, new AppellantDetailsMapper().map(asylumCase, caseFlagsMapper, caseDataMapper));
+        assertEquals(expected, new AppellantDetailsMapper(languageAndAdjustmentsMapper)
+            .map(asylumCase, caseFlagsMapper, caseDataMapper));
     }
 
     @Test
@@ -90,8 +96,10 @@ class AppellantDetailsMapperTest {
             .otherReasonableAdjustmentDetails("Single sex court: Male;")
             .build();
         PartyDetailsModel expected = getPartyDetailsModelForAppellant(individualDetails);
+        when(languageAndAdjustmentsMapper.processPartyCaseFlags(asylumCase, expected)).thenReturn(expected);
 
-        assertEquals(expected, new AppellantDetailsMapper().map(asylumCase, caseFlagsMapper, caseDataMapper));
+        assertEquals(expected, new AppellantDetailsMapper(languageAndAdjustmentsMapper)
+            .map(asylumCase, caseFlagsMapper, caseDataMapper));
     }
 
     private PartyDetailsModel getPartyDetailsModelForAppellant(IndividualDetailsModel individualDetails) {

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LanguageAndAdjustmentsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LanguageAndAdjustmentsMapperTest.java
@@ -1,20 +1,19 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.mappers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_LEVEL_FLAGS;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_LEVEL_FLAGS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.LACKING_CAPACITY;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.EVIDENCE_GIVEN_IN_PRIVATE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper.INTERPRETER_LANGUAGE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper.OTHER_REASONABLE_ADJUSTMENTS_DETAILS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper.REASONABLE_ADJUSTMENTS;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,13 +27,30 @@ import uk.gov.hmcts.reform.iahearingsapi.domain.entities.CaseFlagDetail;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.CaseFlagValue;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.PartyFlagIdValue;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlag;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.IndividualDetailsModel;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyDetailsModel;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class LanguageAndAdjustmentsMapperTest {
 
+    private static final String APPELLANT_PARTY_ID = "APEL";
+    private static final String WITNESS_PARTY_ID = "WITN";
+    private static final String FIRST_NAME = "firstName";
+    private static final String LAST_NAME = "lastName";
+    private static final String FULL_NAME = FIRST_NAME + " " + LAST_NAME;
+
     @Mock
     private AsylumCase asylumCase;
+
+    @Mock
+    private PartyDetailsModel partyDetailsModel;
+
+    @Mock
+    private IndividualDetailsModel individualDetailsModel;
+
+    @Mock
+    private List<String> reasonableAdjustments;
 
     private LanguageAndAdjustmentsMapper mapper;
 
@@ -44,7 +60,7 @@ public class LanguageAndAdjustmentsMapperTest {
     }
 
     @Test
-    void should_sort_flags_into_fields_when_all_sorts_of_flags_present() {
+    void should_add_flag_values_accordingly_to_appellant_party_details() {
 
         List<CaseFlagDetail> appellantCaseFlagDetails = new ArrayList<>();
         appellantCaseFlagDetails.add(new CaseFlagDetail("id1", CaseFlagValue.builder()
@@ -68,67 +84,88 @@ public class LanguageAndAdjustmentsMapperTest {
 
         when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
             .thenReturn(Optional.of(new StrategicCaseFlag(appellantCaseFlagDetails)));
+        when(partyDetailsModel.getIndividualDetails()).thenReturn(individualDetailsModel);
+        when(partyDetailsModel.getPartyRole()).thenReturn(APPELLANT_PARTY_ID);
+        when(individualDetailsModel.getFirstName()).thenReturn(FIRST_NAME);
+        when(individualDetailsModel.getLastName()).thenReturn(LAST_NAME);
+        when(individualDetailsModel.getReasonableAdjustments()).thenReturn(reasonableAdjustments);
+
+        mapper.processPartyCaseFlags(asylumCase, partyDetailsModel);
+
+        verify(individualDetailsModel, times(1)).setInterpreterLanguage("bfi");
+        verify(reasonableAdjustments, times(1)).addAll(List.of("RA0018"));
+        verify(individualDetailsModel, times(1))
+            .setOtherReasonableAdjustmentDetails("Interpreter: German; "
+                                                 + "Support filling in forms: comment of r.a. flag;");
+    }
+
+    @Test
+    void should_add_flag_values_accordingly_to_witness_party_details() {
+
         when(asylumCase.read(WITNESS_LEVEL_FLAGS))
             .thenReturn(Optional.of(List.of(
-                new PartyFlagIdValue("id3", new StrategicCaseFlag(List.of(
+                new PartyFlagIdValue(FULL_NAME, new StrategicCaseFlag(List.of(
+                    new CaseFlagDetail("id1", CaseFlagValue.builder()
+                        .flagCode(EVIDENCE_GIVEN_IN_PRIVATE.getFlagCode())
+                        .name("Evidence given in private")
+                        .flagComment("asking for privacy")
+                        .status("Active")
+                        .build())))),
+                new PartyFlagIdValue(FULL_NAME, new StrategicCaseFlag(List.of(
+                    new CaseFlagDetail("id2", CaseFlagValue.builder()
+                        .flagCode(LANGUAGE_INTERPRETER.getFlagCode())
+                        .subTypeValue("Sardinian")
+                        .status("Active")
+                        .build())))),
+                new PartyFlagIdValue(FULL_NAME, new StrategicCaseFlag(List.of(
                     new CaseFlagDetail("id3", CaseFlagValue.builder()
                         .flagCode(LANGUAGE_INTERPRETER.getFlagCode())
                         .subTypeKey("ita")
                         .subTypeValue("Italian")
                         .status("Active")
                         .build())))),
-                new PartyFlagIdValue("id4", new StrategicCaseFlag(List.of(
+                new PartyFlagIdValue(FULL_NAME, new StrategicCaseFlag(List.of(
                     new CaseFlagDetail("id4", CaseFlagValue.builder()
                         .flagCode(LANGUAGE_INTERPRETER.getFlagCode())
                         .subTypeKey("por")
                         .subTypeValue("Portuguese")
                         .status("Active")
+                        .build())))),
+                new PartyFlagIdValue("Another name", new StrategicCaseFlag(List.of(
+                    new CaseFlagDetail("id5", CaseFlagValue.builder()
+                        .flagCode(LANGUAGE_INTERPRETER.getFlagCode())
+                        .subTypeKey("spa")
+                        .subTypeValue("Spanish")
+                        .status("Active")
+                        .build())))),
+                new PartyFlagIdValue(FULL_NAME, new StrategicCaseFlag(List.of(
+                    new CaseFlagDetail("id6", CaseFlagValue.builder()
+                        .name("Support filling in forms")
+                        .flagComment("comment of r.a. flag")
+                        .flagCode("RA0018")
+                        .status("Active")
                         .build()))))
             )));
 
-        Map<String, List<String>> result = mapper.getLanguageAndAdjustmentsFields(asylumCase);
+        when(partyDetailsModel.getIndividualDetails()).thenReturn(individualDetailsModel);
+        when(partyDetailsModel.getPartyRole()).thenReturn(WITNESS_PARTY_ID);
+        when(individualDetailsModel.getFirstName()).thenReturn(FIRST_NAME);
+        when(individualDetailsModel.getLastName()).thenReturn(LAST_NAME);
+        when(individualDetailsModel.getReasonableAdjustments()).thenReturn(reasonableAdjustments);
 
-        assertEquals(List.of("bfi"), result.get(INTERPRETER_LANGUAGE));
-        assertTrue(result.get(REASONABLE_ADJUSTMENTS).contains("RA0018"));
-        assertTrue(result.get(OTHER_REASONABLE_ADJUSTMENTS_DETAILS).contains("Interpreter: German"));
-        assertTrue(result.get(OTHER_REASONABLE_ADJUSTMENTS_DETAILS).contains("Interpreter: Italian"));
-        assertTrue(result.get(OTHER_REASONABLE_ADJUSTMENTS_DETAILS).contains("Interpreter: Portuguese"));
-        assertTrue(result.get(OTHER_REASONABLE_ADJUSTMENTS_DETAILS).contains("Support filling in forms: "
-                                                                             + "comment of r.a. flag"));
+        mapper.processPartyCaseFlags(asylumCase, partyDetailsModel);
+
+        verify(individualDetailsModel, times(1)).setInterpreterLanguage("ita");
+        verify(reasonableAdjustments, times(1)).addAll(List.of("SM0004", "RA0018"));
+        verify(individualDetailsModel, times(1))
+            .setOtherReasonableAdjustmentDetails("Interpreter: Portuguese; "
+                                                 + "Interpreter: Sardinian; "
+                                                 + "Evidence given in private: asking for privacy; "
+                                                 + "Support filling in forms: comment of r.a. flag;");
     }
 
     @Test
-    void should_sort_flags_into_fields_when_no_eligible_flag_present() {
-
-        List<CaseFlagDetail> appellantCaseFlagDetails = new ArrayList<>();
-
-        appellantCaseFlagDetails.add(new CaseFlagDetail("id1", CaseFlagValue.builder()
-            .name("Lacking capacity")
-            .flagComment("small capacity")
-            .flagCode(LACKING_CAPACITY.getFlagCode())
-            .status("Active")
-            .build()));
-        appellantCaseFlagDetails.add(new CaseFlagDetail("id2", CaseFlagValue.builder()
-            .name("Lacking capacity")
-            .flagComment("small capacity")
-            .flagCode(LACKING_CAPACITY.getFlagCode())
-            .status("Active")
-            .build()));
-
-        when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
-            .thenReturn(Optional.of(new StrategicCaseFlag(appellantCaseFlagDetails)));
-        when(asylumCase.read(WITNESS_LEVEL_FLAGS))
-            .thenReturn(Optional.empty());
-
-        Map<String, List<String>> result = mapper.getLanguageAndAdjustmentsFields(asylumCase);
-
-        assertEquals(List.of(""), result.get(INTERPRETER_LANGUAGE));
-        assertTrue(result.get(REASONABLE_ADJUSTMENTS).isEmpty());
-        assertTrue(result.get(OTHER_REASONABLE_ADJUSTMENTS_DETAILS).isEmpty());
-    }
-
-    @Test
-    void should_not_consider_inactive_flags() {
+    void should_add_nothing_to_individual_details_when_no_qualifying_active_flags_exist() {
 
         List<CaseFlagDetail> appellantCaseFlagDetails = new ArrayList<>();
         appellantCaseFlagDetails.add(new CaseFlagDetail("id1", CaseFlagValue.builder()
@@ -140,37 +177,17 @@ public class LanguageAndAdjustmentsMapperTest {
 
         when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
             .thenReturn(Optional.of(new StrategicCaseFlag(appellantCaseFlagDetails)));
-        when(asylumCase.read(WITNESS_LEVEL_FLAGS))
-            .thenReturn(Optional.empty());
+        when(partyDetailsModel.getIndividualDetails()).thenReturn(individualDetailsModel);
+        when(partyDetailsModel.getPartyRole()).thenReturn(APPELLANT_PARTY_ID);
+        when(individualDetailsModel.getFirstName()).thenReturn(FIRST_NAME);
+        when(individualDetailsModel.getLastName()).thenReturn(LAST_NAME);
+        when(individualDetailsModel.getReasonableAdjustments()).thenReturn(reasonableAdjustments);
 
-        Map<String, List<String>> result = mapper.getLanguageAndAdjustmentsFields(asylumCase);
+        mapper.processPartyCaseFlags(asylumCase, partyDetailsModel);
 
-        assertEquals(List.of(""), result.get(INTERPRETER_LANGUAGE));
-        assertTrue(result.get(REASONABLE_ADJUSTMENTS).isEmpty());
-        assertTrue(result.get(OTHER_REASONABLE_ADJUSTMENTS_DETAILS).isEmpty());
-    }
-
-    @Test
-    void should_write_manually_typed_languages_in_other_reasonable_adjustments() {
-
-        List<CaseFlagDetail> appellantCaseFlagDetails = new ArrayList<>();
-        appellantCaseFlagDetails.add(new CaseFlagDetail("id1", CaseFlagValue.builder()
-            .flagCode(LANGUAGE_INTERPRETER.getFlagCode())
-            .subTypeKey(null)
-            .subTypeValue("Bavarian")
-            .status("Active")
-            .build()));
-
-        when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
-            .thenReturn(Optional.of(new StrategicCaseFlag(appellantCaseFlagDetails)));
-        when(asylumCase.read(WITNESS_LEVEL_FLAGS))
-            .thenReturn(Optional.empty());
-
-        Map<String, List<String>> result = mapper.getLanguageAndAdjustmentsFields(asylumCase);
-
-        assertEquals(List.of(""), result.get(INTERPRETER_LANGUAGE));
-        assertTrue(result.get(REASONABLE_ADJUSTMENTS).isEmpty());
-        assertTrue(result.get(OTHER_REASONABLE_ADJUSTMENTS_DETAILS).contains("Interpreter: Bavarian"));
+        verify(individualDetailsModel, times(1)).setInterpreterLanguage(null);
+        verify(reasonableAdjustments, times(1)).addAll(Collections.emptyList());
+        verify(individualDetailsModel, never()).setOtherReasonableAdjustmentDetails(anyString());
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/WitnessDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/WitnessDetailsMapperTest.java
@@ -23,6 +23,8 @@ class WitnessDetailsMapperTest {
     private AsylumCase asylumCase;
     @Mock
     private CaseDataToServiceHearingValuesMapper caseDataMapper;
+    @Mock
+    private LanguageAndAdjustmentsMapper languageAndAdjustmentsMapper;
 
     @Test
     void should_map_correctly() {
@@ -40,15 +42,15 @@ class WitnessDetailsMapperTest {
             .lastName("witnessFamilyName")
             .preferredHearingChannel("hearingChannel")
             .build();
-        List<PartyDetailsModel> expected = List.of(
-            PartyDetailsModel.builder()
-                .individualDetails(individualDetails)
-                .partyID("partyId")
-                .partyType("IND")
-                .partyRole("WITN")
-                .build()
-        );
+        PartyDetailsModel expectedParty = PartyDetailsModel.builder()
+            .individualDetails(individualDetails)
+            .partyID("partyId")
+            .partyType("IND")
+            .partyRole("WITN")
+            .build();
+        List<PartyDetailsModel> expected = List.of(expectedParty);
+        when(languageAndAdjustmentsMapper.processPartyCaseFlags(asylumCase, expectedParty)).thenReturn(expectedParty);
 
-        assertEquals(expected, new WitnessDetailsMapper().map(asylumCase, caseDataMapper));
+        assertEquals(expected, new WitnessDetailsMapper(languageAndAdjustmentsMapper).map(asylumCase, caseDataMapper));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProviderTest.java
@@ -60,9 +60,6 @@ class ServiceHearingValuesProviderTest {
     private final String dateRangeEnd = "2023-08-15";
     private final String caseDeepLink = "/cases/case-details/1234567891234567#Overview";
     private final String listingComments = "Customer behaviour: unfriendly";
-    private final List<String> interpreterLanguage = List.of("deu");
-    private final List<String> reasonableAdjustments = List.of("Interpreter: Greek");
-    private final List<String> otherReasonableAdjustmentsDetails = List.of("Support filling in forms: Comment here");
     private final HearingWindowModel hearingWindowModel = HearingWindowModel.builder()
         .dateRangeStart(dateStr)
         .dateRangeEnd(dateRangeEnd)
@@ -241,9 +238,6 @@ class ServiceHearingValuesProviderTest {
             .vocabulary(Collections.emptyList())
             .hearingChannels(hearingChannels)
             .hearingLevelParticipantAttendance(Collections.emptyList())
-            .interpreterLanguage(interpreterLanguage.get(0))
-            .reasonableAdjustments(reasonableAdjustments)
-            .otherReasonableAdjustmentsDetails(otherReasonableAdjustmentsDetails)
             .build();
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProviderTest.java
@@ -147,11 +147,6 @@ class ServiceHearingValuesProviderTest {
         when(caseFlagsMapper.getCaseInterpreterRequiredFlag(asylumCase)).thenReturn(true);
         when(caseFlagsMapper.getCaseFlags(asylumCase, caseReference)).thenReturn(caseflags);
         when(partyDetailsMapper.map(asylumCase, caseFlagsMapper, caseDataMapper)).thenReturn(partyDetails);
-        when(languageAndAdjustmentsMapper.getLanguageAndAdjustmentsFields(asylumCase)).thenReturn(Map.of(
-            INTERPRETER_LANGUAGE, interpreterLanguage,
-            REASONABLE_ADJUSTMENTS, reasonableAdjustments,
-            OTHER_REASONABLE_ADJUSTMENTS_DETAILS, otherReasonableAdjustmentsDetails
-        ));
 
         caseCategoryCaseType.setCategoryType(CategoryType.CASE_TYPE);
         caseCategoryCaseType.setCategoryValue(caseCategoriesValue);

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProviderTest.java
@@ -9,16 +9,12 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.ANONYMITY;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper.INTERPRETER_LANGUAGE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper.OTHER_REASONABLE_ADJUSTMENTS_DETAILS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper.REASONABLE_ADJUSTMENTS;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7617](https://tools.hmcts.net/jira/browse/RIA-7617)


### Change description ###
- Fix the logic in order to populate `reasonableAdjustments`, `otherReasonableAdjustmentDetails` and `interpreterLanguage` inside the partyDetails of appellant and witnesses

What this code is supposed to do is:
- go through the each group of flags per party (appellant flags, witness 1 flags, witness 2 flags etc.) and for each:
  - separate the language flags from reasonable adjustments flags
  - write the flag-codes of the reasonable adjustment flags in partyDetails.individualDetails.reasonableAdjustments
  - sort the language flags so that one with language-code is selected and its code populates partyDetails.individualDetails.interpreterLanguage
  - take the remaining language flags (with and without language-code) and write its full name in partyDetails.individualDetails.otherReasonableAdjustmentDetails in the format "Interpreter: French"
  - take the reasonable adjustment flag comments and append them in partyDetails.individualDetails.otherReasonableAdjustmentDetails in the format "Evidence given in private: comment body here;" 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
