### PR TITLE
RIA-8020 Prevent partiesNotifiedUpdate when needed info missing

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/hmc/ListAssistCaseStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/hmc/ListAssistCaseStatus.java
@@ -12,7 +12,9 @@ public enum ListAssistCaseStatus {
     LISTED("Listed"),
     PENDING_RELISTING("Pending Relisting"),
     HEARING_COMPLETED("Hearing Completed"),
-    CASE_CLOSED("Case Closed");
+    CASE_CLOSED("Case Closed"),
+    CLOSED("CLOSED"),
+    EXCEPTION("EXCEPTION");
 
     private final String label;
 }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/HearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/HearingService.java
@@ -3,13 +3,11 @@ package uk.gov.hmcts.reform.iahearingsapi.domain.service;
 import static java.util.Objects.requireNonNull;
 
 import feign.FeignException;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.validation.constraints.NotNull;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -70,7 +68,7 @@ public class HearingService {
     }
 
     public HearingGetResponse getHearing(String hearingId) throws HmcException {
-        log.debug("Sending Get Hearings with Hearing ID {}", hearingId);
+        log.info("Sending GetHearings request with Hearing ID {}", hearingId);
         try {
             String serviceUserToken = idamService.getServiceUserToken();
             String serviceAuthToken = serviceAuthTokenGenerator.generate();


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8020](https://tools.hmcts.net/jira/browse/RIA-8020)


### Change description ###
- Added missing constants in `ListAssistCaseStatus`
- Prevented update of partiesNotified when either versionNumber or receivedDateTime is null, as they're both needed to retrieve an entry where partiesNotified are stored (the HearingResponse table)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
