### PR TITLE
RIA-7700 Booking statuses in otherReasonableAdjustmentsDetails

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -171,6 +171,71 @@ public enum AsylumCaseFieldDefinition {
         "deportationOrderOptions", new TypeReference<YesOrNo>(){}),
     APPEAL_TYPE(
         "appealType", new TypeReference<AppealType>(){}),
+    APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS(
+        "appellantInterpreterSpokenLanguageBookingStatus", new TypeReference<InterpreterBookingStatus>() {}),
+
+    APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS(
+        "appellantInterpreterSignLanguageBookingStatus", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_1(
+        "witnessInterpreterSpokenLanguageBookingStatus1", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_2(
+        "witnessInterpreterSpokenLanguageBookingStatus2", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_3(
+        "witnessInterpreterSpokenLanguageBookingStatus3", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_4(
+        "witnessInterpreterSpokenLanguageBookingStatus4", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_5(
+        "witnessInterpreterSpokenLanguageBookingStatus5", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_6(
+        "witnessInterpreterSpokenLanguageBookingStatus6", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_7(
+        "witnessInterpreterSpokenLanguageBookingStatus7", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_8(
+        "witnessInterpreterSpokenLanguageBookingStatus8", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_9(
+        "witnessInterpreterSpokenLanguageBookingStatus9", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_10(
+        "witnessInterpreterSpokenLanguageBookingStatus10", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_1(
+        "witnessInterpreterSignLanguageBookingStatus1", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_2(
+        "witnessInterpreterSignLanguageBookingStatus2", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_3(
+        "witnessInterpreterSignLanguageBookingStatus3", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_4(
+        "witnessInterpreterSignLanguageBookingStatus4", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_5(
+        "witnessInterpreterSignLanguageBookingStatus5", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_6(
+        "witnessInterpreterSignLanguageBookingStatus6", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_7(
+        "witnessInterpreterSignLanguageBookingStatus7", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_8(
+        "witnessInterpreterSignLanguageBookingStatus8", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_9(
+        "witnessInterpreterSignLanguageBookingStatus9", new TypeReference<InterpreterBookingStatus>() {}),
+
+    WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_10(
+        "witnessInterpreterSignLanguageBookingStatus10", new TypeReference<InterpreterBookingStatus>() {}),
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/InterpreterBookingStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/InterpreterBookingStatus.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.iahearingsapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum InterpreterBookingStatus {
+
+    NOT_REQUESTED("notRequested", "Not requested"),
+    REQUESTED("requested", "Requested"),
+    BOOKED("booked", "Booked"),
+    CANCELLED("cancelled", "Cancelled");
+
+    @JsonValue
+    private final String value;
+
+    private final String desc;
+
+    InterpreterBookingStatus(String value, String desc) {
+        this.value = value;
+        this.desc = desc;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapper.java
@@ -3,19 +3,25 @@ package uk.gov.hmcts.reform.iahearingsapi.domain.mappers;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_FAMILY_NAME;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_GIVEN_NAMES;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_PHONE_NUMBER;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.EMAIL;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.IS_SINGLE_SEX_COURT_ALLOWED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MOBILE_NUMBER;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.SINGLE_SEX_COURT_TYPE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.GrantedRefusedType.GRANTED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.NOT_REQUESTED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.SingleSexType.MALE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.PartyDetailsMapper.appendBookingStatus;
 
 import java.util.Collections;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.IndividualDetailsModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyDetailsModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyType;
@@ -77,6 +83,24 @@ public class AppellantDetailsMapper {
             .unavailabilityRanges(caseDataMapper.getUnavailabilityRanges(asylumCase))
             .build();
 
-        return languageAndAdjustmentsMapper.processPartyCaseFlags(asylumCase, appellantPartyDetailsModel);
+        languageAndAdjustmentsMapper.processPartyCaseFlags(asylumCase, appellantPartyDetailsModel);
+
+        appendAppellantBookingStatus(asylumCase, appellantPartyDetailsModel);
+
+        return appellantPartyDetailsModel;
+    }
+
+    private void appendAppellantBookingStatus(AsylumCase asylumCase,
+                                              PartyDetailsModel appellantPartyDetailsModel) {
+
+        Optional<InterpreterBookingStatus> spokenBookingStatus = asylumCase
+            .read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class)
+            .filter(interpreterBookingStatus -> !interpreterBookingStatus.equals(NOT_REQUESTED));
+
+        Optional<InterpreterBookingStatus> signBookingStatus = asylumCase
+            .read(APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class)
+            .filter(interpreterBookingStatus -> !interpreterBookingStatus.equals(NOT_REQUESTED));
+
+        appendBookingStatus(spokenBookingStatus, signBookingStatus, appellantPartyDetailsModel);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/InterpreterLanguagesUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/InterpreterLanguagesUtils.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.iahearingsapi.domain.utils;
+
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_1;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_10;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_2;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_3;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_4;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_5;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_6;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_7;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_8;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_9;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_1;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_10;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_2;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_3;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_4;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_5;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_6;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_7;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_8;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_9;
+
+import java.util.List;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition;
+
+public class InterpreterLanguagesUtils {
+
+    public static final List<AsylumCaseFieldDefinition> WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUSES = List.of(
+        WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_1,
+        WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_2,
+        WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_3,
+        WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_4,
+        WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_5,
+        WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_6,
+        WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_7,
+        WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_8,
+        WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_9,
+        WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_10
+    );
+
+    public static final List<AsylumCaseFieldDefinition> WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUSES = List.of(
+        WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_1,
+        WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_2,
+        WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_3,
+        WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_4,
+        WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_5,
+        WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_6,
+        WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_7,
+        WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_8,
+        WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_9,
+        WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_10
+    );
+}

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/WitnessDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/WitnessDetailsMapperTest.java
@@ -57,7 +57,7 @@ class WitnessDetailsMapperTest {
             .partyRole("WITN")
             .build();
         List<PartyDetailsModel> expected = List.of(expectedParty);
-        when(languageAndAdjustmentsMapper.processPartyCaseFlags(asylumCase, any(PartyDetailsModel.class)))
+        when(languageAndAdjustmentsMapper.processPartyCaseFlags(eq(asylumCase), any(PartyDetailsModel.class)))
             .thenReturn(expectedParty);
 
         expected.get(0).getIndividualDetails().setOtherReasonableAdjustmentDetails("");

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/WitnessDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/WitnessDetailsMapperTest.java
@@ -1,16 +1,24 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.mappers;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_DETAILS;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_1;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_1;
 
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.WitnessDetails;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.IndividualDetailsModel;
@@ -33,7 +41,7 @@ class WitnessDetailsMapperTest {
 
         final List<IdValue<WitnessDetails>> witnessDetails = List.of(
             new IdValue<>(
-                "id1", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
+                "1", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
         );
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnessDetails));
 
@@ -49,8 +57,138 @@ class WitnessDetailsMapperTest {
             .partyRole("WITN")
             .build();
         List<PartyDetailsModel> expected = List.of(expectedParty);
-        when(languageAndAdjustmentsMapper.processPartyCaseFlags(asylumCase, expectedParty)).thenReturn(expectedParty);
+        when(languageAndAdjustmentsMapper.processPartyCaseFlags(asylumCase, any(PartyDetailsModel.class)))
+            .thenReturn(expectedParty);
+
+        expected.get(0).getIndividualDetails().setOtherReasonableAdjustmentDetails("");
 
         assertEquals(expected, new WitnessDetailsMapper(languageAndAdjustmentsMapper).map(asylumCase, caseDataMapper));
     }
+
+    @ParameterizedTest
+    @EnumSource(value = InterpreterBookingStatus.class, names = {"BOOKED", "REQUESTED", "CANCELLED", "NOT_REQUESTED"})
+    void should_handle_spoken_interpreter_booking_status(InterpreterBookingStatus bookingStatus) {
+        when(asylumCase.read(WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_1, InterpreterBookingStatus.class))
+            .thenReturn(Optional.of(bookingStatus));
+        when(asylumCase.read(WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_1, InterpreterBookingStatus.class))
+            .thenReturn(Optional.empty());
+
+        when(caseDataMapper.getHearingChannel(asylumCase)).thenReturn("hearingChannel");
+
+        final List<IdValue<WitnessDetails>> witnessDetails = List.of(
+            new IdValue<>(
+                "1", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
+        );
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnessDetails));
+
+        IndividualDetailsModel individualDetails = IndividualDetailsModel.builder()
+            .firstName("witnessName")
+            .lastName("witnessFamilyName")
+            .preferredHearingChannel("hearingChannel")
+            .build();
+        PartyDetailsModel witnessPartyDetailsModel = PartyDetailsModel.builder()
+            .individualDetails(individualDetails)
+            .partyID("partyId")
+            .partyType("IND")
+            .partyRole("WITN")
+            .build();
+        when(languageAndAdjustmentsMapper.processPartyCaseFlags(eq(asylumCase), any(PartyDetailsModel.class)))
+            .thenReturn(witnessPartyDetailsModel);
+
+        String status = bookingStatus != InterpreterBookingStatus.NOT_REQUESTED
+            ? " Status: " + bookingStatus.getDesc() + ";"
+            : "";
+
+        witnessPartyDetailsModel.getIndividualDetails().setOtherReasonableAdjustmentDetails(
+            (requireNonNullElse(witnessPartyDetailsModel.getIndividualDetails().getOtherReasonableAdjustmentDetails(),
+                               "") + status).trim());
+
+        assertEquals(List.of(witnessPartyDetailsModel), new WitnessDetailsMapper(languageAndAdjustmentsMapper)
+            .map(asylumCase, caseDataMapper));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = InterpreterBookingStatus.class, names = {"BOOKED", "REQUESTED", "CANCELLED", "NOT_REQUESTED"})
+    void should_handle_sign_interpreter_booking_status(InterpreterBookingStatus bookingStatus) {
+        when(asylumCase.read(WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_1, InterpreterBookingStatus.class))
+            .thenReturn(Optional.empty());
+        when(asylumCase.read(WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_1, InterpreterBookingStatus.class))
+            .thenReturn(Optional.of(bookingStatus));
+
+        when(caseDataMapper.getHearingChannel(asylumCase)).thenReturn("hearingChannel");
+
+        final List<IdValue<WitnessDetails>> witnessDetails = List.of(
+            new IdValue<>(
+                "1", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
+        );
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnessDetails));
+
+        IndividualDetailsModel individualDetails = IndividualDetailsModel.builder()
+            .firstName("witnessName")
+            .lastName("witnessFamilyName")
+            .preferredHearingChannel("hearingChannel")
+            .build();
+        PartyDetailsModel witnessPartyDetailsModel = PartyDetailsModel.builder()
+            .individualDetails(individualDetails)
+            .partyID("partyId")
+            .partyType("IND")
+            .partyRole("WITN")
+            .build();
+        when(languageAndAdjustmentsMapper.processPartyCaseFlags(eq(asylumCase), any(PartyDetailsModel.class)))
+            .thenReturn(witnessPartyDetailsModel);
+
+        String status = bookingStatus != InterpreterBookingStatus.NOT_REQUESTED
+            ? " Status: " + bookingStatus.getDesc() + ";"
+            : "";
+
+        witnessPartyDetailsModel.getIndividualDetails().setOtherReasonableAdjustmentDetails(
+            (requireNonNullElse(witnessPartyDetailsModel.getIndividualDetails().getOtherReasonableAdjustmentDetails(),
+                                "") + status).trim());
+
+        assertEquals(List.of(witnessPartyDetailsModel), new WitnessDetailsMapper(languageAndAdjustmentsMapper)
+            .map(asylumCase, caseDataMapper));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = InterpreterBookingStatus.class, names = {"BOOKED", "REQUESTED", "CANCELLED", "NOT_REQUESTED"})
+    void should_handle_both_spoken_and_sign_interpreter_booking_status(InterpreterBookingStatus bookingStatus) {
+        when(asylumCase.read(WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_1, InterpreterBookingStatus.class))
+            .thenReturn(Optional.of(bookingStatus));
+        when(asylumCase.read(WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_1, InterpreterBookingStatus.class))
+            .thenReturn(Optional.of(bookingStatus));
+
+        when(caseDataMapper.getHearingChannel(asylumCase)).thenReturn("hearingChannel");
+
+        final List<IdValue<WitnessDetails>> witnessDetails = List.of(
+            new IdValue<>(
+                "1", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
+        );
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnessDetails));
+
+        IndividualDetailsModel individualDetails = IndividualDetailsModel.builder()
+            .firstName("witnessName")
+            .lastName("witnessFamilyName")
+            .preferredHearingChannel("hearingChannel")
+            .build();
+        PartyDetailsModel witnessPartyDetailsModel = PartyDetailsModel.builder()
+            .individualDetails(individualDetails)
+            .partyID("partyId")
+            .partyType("IND")
+            .partyRole("WITN")
+            .build();
+        when(languageAndAdjustmentsMapper.processPartyCaseFlags(eq(asylumCase), any(PartyDetailsModel.class)))
+            .thenReturn(witnessPartyDetailsModel);
+
+        String status = bookingStatus != InterpreterBookingStatus.NOT_REQUESTED
+            ? " Status (Spoken): " + bookingStatus.getDesc() + "; Status (Sign): " + bookingStatus.getDesc() + ";"
+            : "";
+
+        witnessPartyDetailsModel.getIndividualDetails().setOtherReasonableAdjustmentDetails(
+            (requireNonNullElse(witnessPartyDetailsModel.getIndividualDetails().getOtherReasonableAdjustmentDetails(),
+                                "") + status).trim());
+
+        assertEquals(List.of(witnessPartyDetailsModel), new WitnessDetailsMapper(languageAndAdjustmentsMapper)
+            .map(asylumCase, caseDataMapper));
+    }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7700](https://tools.hmcts.net/jira/browse/RIA-7700)


### Change description ###
- Added booking status of interpreters to `otherReasonableAdjustmentsDetails` of individual details for each party (witnesses and appellant)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
