### PR TITLE
RIA-7972 Write party details when updating hearing requests

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapper.java
@@ -11,7 +11,6 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MOBILE_NUMBER;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.SINGLE_SEX_COURT_TYPE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.GrantedRefusedType.GRANTED;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.NOT_REQUESTED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.SingleSexType.MALE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.PartyDetailsMapper.appendBookingStatus;
 
@@ -94,12 +93,10 @@ public class AppellantDetailsMapper {
                                               PartyDetailsModel appellantPartyDetailsModel) {
 
         Optional<InterpreterBookingStatus> spokenBookingStatus = asylumCase
-            .read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class)
-            .filter(interpreterBookingStatus -> !interpreterBookingStatus.equals(NOT_REQUESTED));
+            .read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class);
 
         Optional<InterpreterBookingStatus> signBookingStatus = asylumCase
-            .read(APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class)
-            .filter(interpreterBookingStatus -> !interpreterBookingStatus.equals(NOT_REQUESTED));
+            .read(APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class);
 
         appendBookingStatus(spokenBookingStatus, signBookingStatus, appellantPartyDetailsModel);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/PartyDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/PartyDetailsMapper.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.mappers;
 
 import static java.util.Objects.requireNonNullElse;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -65,16 +66,16 @@ public class PartyDetailsMapper {
                 .append(STATUS_SIGN)
                 .append(signBookingStatus.get().getDesc())
                 .append(";");
-        } else if (spokenBookingStatus.isPresent()) {
+        } else if (spokenBookingStatus.isPresent() && !spokenBookingStatus.get().equals(NOT_REQUESTED)) {
             status
                 .append(STATUS)
                 .append(spokenBookingStatus.get().getDesc())
                 .append(";");
-        } else {
-            signBookingStatus.ifPresent(interpreterBookingStatus -> status
+        } else if (signBookingStatus.isPresent() && !signBookingStatus.get().equals(NOT_REQUESTED)) {
+            status
                 .append(STATUS)
-                .append(interpreterBookingStatus.getDesc())
-                .append(";"));
+                .append(signBookingStatus.get().getDesc())
+                .append(";");
         }
 
         String otherReasonableAdjustments = requireNonNullElse(partyDetailsModel.getIndividualDetails()

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/PartyDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/PartyDetailsMapper.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.mappers;
 
 import static java.util.Objects.requireNonNullElse;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.*;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.NOT_REQUESTED;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,7 +58,10 @@ public class PartyDetailsMapper {
         //String status;
         StringBuilder status = new StringBuilder();
 
-        if (spokenBookingStatus.isPresent() && signBookingStatus.isPresent()) {
+        if (spokenBookingStatus.isPresent()
+            && signBookingStatus.isPresent()
+            && (!spokenBookingStatus.get().equals(NOT_REQUESTED)
+                || !signBookingStatus.get().equals(NOT_REQUESTED))) {
             status
                 .append(STATUS_SPOKEN)
                 .append(spokenBookingStatus.get().getDesc())

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/WitnessDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/WitnessDetailsMapper.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.mappers;
 
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_DETAILS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.NOT_REQUESTED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.PartyDetailsMapper.appendBookingStatus;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.utils.InterpreterLanguagesUtils.WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUSES;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.utils.InterpreterLanguagesUtils.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUSES;
@@ -62,12 +61,10 @@ public class WitnessDetailsMapper {
         int id = Integer.parseInt(witnessDetailsIdValue.getId());
 
         Optional<InterpreterBookingStatus> spokenBookingStatus = asylumCase
-            .read(WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUSES.get(id - 1), InterpreterBookingStatus.class)
-            .filter(interpreterBookingStatus -> !interpreterBookingStatus.equals(NOT_REQUESTED));
+            .read(WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUSES.get(id - 1), InterpreterBookingStatus.class);
 
         Optional<InterpreterBookingStatus> signBookingStatus = asylumCase
-            .read(WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUSES.get(id - 1), InterpreterBookingStatus.class)
-            .filter(interpreterBookingStatus -> !interpreterBookingStatus.equals(NOT_REQUESTED));
+            .read(WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUSES.get(id - 1), InterpreterBookingStatus.class);
 
         appendBookingStatus(spokenBookingStatus, signBookingStatus, witnessPartyDetailsModel);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapperTest.java
@@ -10,6 +10,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.IS_SINGLE_SEX_COURT_ALLOWED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.SINGLE_SEX_COURT_TYPE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.NOT_REQUESTED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.JourneyType.REP;
 
 import java.util.Collections;
@@ -135,7 +136,7 @@ class AppellantDetailsMapperTest {
         when(languageAndAdjustmentsMapper.processPartyCaseFlags(eq(asylumCase), any(PartyDetailsModel.class)))
             .thenReturn(appellantPartyDetailsModel);
 
-        String status = bookingStatus != InterpreterBookingStatus.NOT_REQUESTED
+        String status = bookingStatus != NOT_REQUESTED
             ? " Status: " + bookingStatus.getDesc() + ";"
             : "";
 
@@ -171,7 +172,7 @@ class AppellantDetailsMapperTest {
         when(languageAndAdjustmentsMapper.processPartyCaseFlags(eq(asylumCase), any(PartyDetailsModel.class)))
             .thenReturn(appellantPartyDetailsModel);
 
-        String status = bookingStatus != InterpreterBookingStatus.NOT_REQUESTED
+        String status = bookingStatus != NOT_REQUESTED
             ? " Status: " + bookingStatus.getDesc() + ";"
             : "";
 
@@ -218,8 +219,15 @@ class AppellantDetailsMapperTest {
                                      .getOtherReasonableAdjustmentDetails(),
                                 "") + status).trim()));
 
-        assertEquals(appellantPartyDetailsModel, new AppellantDetailsMapper(languageAndAdjustmentsMapper)
-            .map(asylumCase, caseFlagsMapper, caseDataMapper));
+        if (!bookingStatus.equals(NOT_REQUESTED)) {
+            assertEquals(appellantPartyDetailsModel, new AppellantDetailsMapper(languageAndAdjustmentsMapper)
+                .map(asylumCase, caseFlagsMapper, caseDataMapper));
+        } else {
+            appellantPartyDetailsModel.getIndividualDetails()
+                .setOtherReasonableAdjustmentDetails("Single sex court: Male;");
+            assertEquals(appellantPartyDetailsModel, new AppellantDetailsMapper(languageAndAdjustmentsMapper)
+                .map(asylumCase, caseFlagsMapper, caseDataMapper));
+        }
     }
 
     private PartyDetailsModel getPartyDetailsModelForAppellant(IndividualDetailsModel individualDetails) {

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/AppellantDetailsMapperTest.java
@@ -207,9 +207,11 @@ class AppellantDetailsMapperTest {
         when(languageAndAdjustmentsMapper.processPartyCaseFlags(eq(asylumCase), any(PartyDetailsModel.class)))
             .thenReturn(appellantPartyDetailsModel);
 
-        String status = bookingStatus != InterpreterBookingStatus.NOT_REQUESTED
-            ? " Status (Spoken): " + bookingStatus.getDesc() + "; Status (Sign): " + bookingStatus.getDesc() + ";"
-            : "";
+        String status = " Status (Spoken): "
+                        + bookingStatus.getDesc()
+                        + "; Status (Sign): "
+                        + bookingStatus.getDesc()
+                        + ";";
 
         appellantPartyDetailsModel.getIndividualDetails().setOtherReasonableAdjustmentDetails(
             ((requireNonNullElse(appellantPartyDetailsModel.getIndividualDetails()

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/PartyDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/PartyDetailsMapperTest.java
@@ -2,17 +2,28 @@ package uk.gov.hmcts.reform.iahearingsapi.domain.mappers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.BOOKED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.CANCELLED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.NOT_REQUESTED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.REQUESTED;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.IndividualDetailsModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyDetailsModel;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,6 +49,8 @@ class PartyDetailsMapperTest {
     private WitnessDetailsMapper witnessDetailsMapper;
     @Mock
     private InterpreterDetailsMapper interpreterDetailsMapper;
+    @Mock
+    private PartyDetailsModel partyDetailsModel;
 
     @Test
     void should_map_correctly() {
@@ -76,5 +89,96 @@ class PartyDetailsMapperTest {
         );
 
         assertEquals(expected, mapper.map(asylumCase, caseFlagsMapper, caseDataMapper));
+    }
+
+    static Stream<Arguments> bothSpokenAndSignStatuses() {
+        return Stream.of(
+            Arguments.of(BOOKED, REQUESTED),
+            Arguments.of(BOOKED, BOOKED),
+            Arguments.of(BOOKED, CANCELLED),
+            Arguments.of(BOOKED, NOT_REQUESTED),
+            Arguments.of(REQUESTED, REQUESTED),
+            Arguments.of(REQUESTED, CANCELLED),
+            Arguments.of(REQUESTED, NOT_REQUESTED),
+            Arguments.of(CANCELLED, CANCELLED),
+            Arguments.of(CANCELLED, NOT_REQUESTED),
+            Arguments.of(NOT_REQUESTED, NOT_REQUESTED)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("bothSpokenAndSignStatuses")
+    void should_handle_spoken_and_sign_interpreter_booking_status(InterpreterBookingStatus spokenBookingStatus,
+                                                         InterpreterBookingStatus signBookingStatus) {
+
+        PartyDetailsModel partyDetailsModel = PartyDetailsModel.builder()
+            .individualDetails(IndividualDetailsModel.builder().build())
+            .build();
+
+        PartyDetailsModel result = PartyDetailsMapper.appendBookingStatus(
+            Optional.of(spokenBookingStatus),
+            Optional.of(signBookingStatus),
+            partyDetailsModel);
+
+        String expected = "Status (Spoken): "
+                          + spokenBookingStatus.getDesc()
+                          + "; Status (Sign): "
+                          + signBookingStatus.getDesc()
+                          + ";";
+
+        if (spokenBookingStatus.equals(NOT_REQUESTED)
+            && signBookingStatus.equals(NOT_REQUESTED)) {
+            assertEquals("", result.getIndividualDetails().getOtherReasonableAdjustmentDetails());
+        } else {
+            assertEquals(expected, result.getIndividualDetails().getOtherReasonableAdjustmentDetails());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = InterpreterBookingStatus.class, names = {"BOOKED", "REQUESTED", "CANCELLED", "NOT_REQUESTED"})
+    void should_handle_spoken_interpreter_booking_status(InterpreterBookingStatus spokenBookingStatus) {
+
+        PartyDetailsModel partyDetailsModel = PartyDetailsModel.builder()
+            .individualDetails(IndividualDetailsModel.builder().build())
+            .build();
+
+        PartyDetailsModel result = PartyDetailsMapper.appendBookingStatus(
+            Optional.of(spokenBookingStatus),
+            Optional.empty(),
+            partyDetailsModel);
+
+        String expected = "Status: "
+                          + spokenBookingStatus.getDesc()
+                          + ";";
+
+        if (spokenBookingStatus.equals(NOT_REQUESTED)) {
+            assertEquals("", result.getIndividualDetails().getOtherReasonableAdjustmentDetails());
+        } else {
+            assertEquals(expected, result.getIndividualDetails().getOtherReasonableAdjustmentDetails());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = InterpreterBookingStatus.class, names = {"BOOKED", "REQUESTED", "CANCELLED", "NOT_REQUESTED"})
+    void should_handle_sign_interpreter_booking_status(InterpreterBookingStatus signBookingStatus) {
+
+        PartyDetailsModel partyDetailsModel = PartyDetailsModel.builder()
+            .individualDetails(IndividualDetailsModel.builder().build())
+            .build();
+
+        PartyDetailsModel result = PartyDetailsMapper.appendBookingStatus(
+            Optional.empty(),
+            Optional.of(signBookingStatus),
+            partyDetailsModel);
+
+        String expected = "Status: "
+                          + signBookingStatus.getDesc()
+                          + ";";
+
+        if (signBookingStatus.equals(NOT_REQUESTED)) {
+            assertEquals("", result.getIndividualDetails().getOtherReasonableAdjustmentDetails());
+        } else {
+            assertEquals(expected, result.getIndividualDetails().getOtherReasonableAdjustmentDetails());
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadServiceTest.java
@@ -41,6 +41,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.Facilities.IAC_T
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class UpdateHearingPayloadServiceTest {
+
     @Mock
     private HearingService hearingService;
     @Mock
@@ -53,6 +54,8 @@ class UpdateHearingPayloadServiceTest {
     HearingGetResponse hearingGetResponse;
     @Mock
     private AsylumCase asylumCase;
+    @Mock
+    private PartyDetailsModel partyDetailsModel;
     HearingDetails hearingDetails = new HearingDetails();
     private final String updateHearingsCode = "code 1";
     UpdateHearingPayloadService updateHearingPayloadService;
@@ -280,6 +283,22 @@ class UpdateHearingPayloadServiceTest {
 
         assertEquals(partyDetails, updateHearingRequest.getPartyDetails());
         assertEqualsHearingDetails(updateHearingRequest);
+    }
+
+    @Test
+    void should_create_an_update_hearing_request_with_updated_party_details() {
+        when(partyDetailsMapper.map(asylumCase, caseFlagsMapper, caseDataMapper))
+            .thenReturn(List.of(partyDetailsModel));
+
+        UpdateHearingRequest updateHearingRequest = updateHearingPayloadService.createUpdateHearingPayload(
+            asylumCase,
+            updateHearingsCode,
+            reasonCode,
+            true,
+            null
+        );
+
+        assertEquals(List.of(partyDetailsModel), updateHearingRequest.getPartyDetails());
     }
 
     private void assertEqualsHearingDetails(UpdateHearingRequest updateHearingRequestSent) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7972](https://tools.hmcts.net/jira/browse/RIA-7972)


### Change description ###
- made any update of the hearing request rebuild the party details, so that each has the updated content for `otherReasonableAdjustmentDetails` where the interpreter booking statuses are supposed to be written
- changed the logic surrounding the qualifying booking statuses, so that `notRequested` is considered when the party has both spoken and sign languages (so that _spoken=notRequested_ and _sign=requested_ the otherReasonableAdjustmentDetails property contains `Status (Spoken): Not Requested; Status (Sign): Requested` instead of `Status: Requested`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
