### PR TITLE
RIA-7700 Infer index of witness elements

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -79,4 +79,7 @@
    ]]></notes>
     <cve>CVE-2023-44487</cve>
   </suppress>
+  <suppress>
+    <cve>CVE-2023-36052</cve>
+  </suppress>
 </suppressions>

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/WitnessDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/WitnessDetailsMapperTest.java
@@ -41,7 +41,7 @@ class WitnessDetailsMapperTest {
 
         final List<IdValue<WitnessDetails>> witnessDetails = List.of(
             new IdValue<>(
-                "1", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
+                "1a", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
         );
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnessDetails));
 
@@ -77,7 +77,7 @@ class WitnessDetailsMapperTest {
 
         final List<IdValue<WitnessDetails>> witnessDetails = List.of(
             new IdValue<>(
-                "1", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
+                "1b", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
         );
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnessDetails));
 
@@ -119,7 +119,7 @@ class WitnessDetailsMapperTest {
 
         final List<IdValue<WitnessDetails>> witnessDetails = List.of(
             new IdValue<>(
-                "1", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
+                "1c", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
         );
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnessDetails));
 
@@ -161,7 +161,7 @@ class WitnessDetailsMapperTest {
 
         final List<IdValue<WitnessDetails>> witnessDetails = List.of(
             new IdValue<>(
-                "1", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
+                "1d", new WitnessDetails("partyId", "witnessName", "witnessFamilyName", null))
         );
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnessDetails));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7700](https://tools.hmcts.net/jira/browse/RIA-7700)


### Change description ###
- Infer index from position in collection rather than IdValue's ids (string numbers in some cases, uuids in AIP before updating hearing requirements)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
