### PR TITLE
RIA-8082 Enable processing of all messages temporarily

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -81,5 +81,6 @@
   </suppress>
   <suppress>
     <cve>CVE-2023-36052</cve>
+    <cve>CVE-2023-35116</cve>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListener.java
@@ -1,12 +1,9 @@
 package uk.gov.hmcts.reform.iahearingsapi.infrastructure.hmc.listeners;
 
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.EXCEPTION;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jms.annotation.JmsListener;
@@ -54,8 +51,9 @@ public class HmcHearingsEventTopicListener {
             log.info("Received message from HMC hearings topic for Case ID {}, and Hearing ID {}.",
                      caseId, hearingId);
 
-            if (isMessageRelevantForService(hmcMessage)
-                && Objects.equals(hmcMessage.getHearingUpdate().getHmcStatus(), EXCEPTION)) {
+            if (isMessageRelevantForService(hmcMessage)) {
+                // TODO: only allow EXCEPTION messages when batch job gets enabled
+                //&& Objects.equals(hmcMessage.getHearingUpdate().getHmcStatus(), EXCEPTION)) {
 
                 log.info("Attempting to process message from HMC hearings topic for"
                              + " Case ID {}, and Hearing ID {} with status EXCEPTION", caseId, hearingId);

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListener.java
@@ -51,9 +51,11 @@ public class HmcHearingsEventTopicListener {
             log.info("Received message from HMC hearings topic for Case ID {}, and Hearing ID {}.",
                      caseId, hearingId);
 
+            /*
+            Disallow messages other than EXCEPTION after batch processing gets enabled
+            Objects.equals(hmcMessage.getHearingUpdate().getHmcStatus(), EXCEPTION)
+             */
             if (isMessageRelevantForService(hmcMessage)) {
-                // TODO: only allow EXCEPTION messages when batch job gets enabled
-                //&& Objects.equals(hmcMessage.getHearingUpdate().getHmcStatus(), EXCEPTION)) {
 
                 log.info("Attempting to process message from HMC hearings topic for"
                              + " Case ID {}, and Hearing ID {} with status EXCEPTION", caseId, hearingId);

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListenerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.EXCEPTION;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.LISTED;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
@@ -71,17 +70,18 @@ class HmcHearingsEventTopicListenerTest {
         verify(hmcMessageProcessor, never()).processMessage(any(HmcMessage.class));
     }
 
-    @Test
-    public void should_not_process_messages_with_hmc_status_different_than_exception() throws Exception {
-        HmcMessage hmcMessage = TestUtils.createHmcMessage(SERVICE_CODE);
-        hmcMessage.setHearingUpdate(HearingUpdate.builder().hmcStatus(LISTED).build());
-        String stringMessage = OBJECT_MAPPER.writeValueAsString(hmcMessage);
-        byte[] message = StandardCharsets.UTF_8.encode(stringMessage).array();
-
-        given(mockObjectMapper.readValue(any(String.class), eq(HmcMessage.class))).willReturn(hmcMessage);
-        hmcHearingsEventTopicListener.onMessage(message);
-
-        verify(hmcMessageProcessor, never()).processMessage(any(HmcMessage.class));
-    }
+    // TODO: enable this test when batch processing is activated (and only EXCEPTION messages will be processed)
+    //@Test
+    //public void should_not_process_messages_with_hmc_status_different_than_exception() throws Exception {
+    //    HmcMessage hmcMessage = TestUtils.createHmcMessage(SERVICE_CODE);
+    //    hmcMessage.setHearingUpdate(HearingUpdate.builder().hmcStatus(LISTED).build());
+    //    String stringMessage = OBJECT_MAPPER.writeValueAsString(hmcMessage);
+    //    byte[] message = StandardCharsets.UTF_8.encode(stringMessage).array();
+    //
+    //    given(mockObjectMapper.readValue(any(String.class), eq(HmcMessage.class))).willReturn(hmcMessage);
+    //    hmcHearingsEventTopicListener.onMessage(message);
+    //
+    //    verify(hmcMessageProcessor, never()).processMessage(any(HmcMessage.class));
+    //}
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListenerTest.java
@@ -70,18 +70,20 @@ class HmcHearingsEventTopicListenerTest {
         verify(hmcMessageProcessor, never()).processMessage(any(HmcMessage.class));
     }
 
-    // TODO: enable this test when batch processing is activated (and only EXCEPTION messages will be processed)
-    //@Test
-    //public void should_not_process_messages_with_hmc_status_different_than_exception() throws Exception {
-    //    HmcMessage hmcMessage = TestUtils.createHmcMessage(SERVICE_CODE);
-    //    hmcMessage.setHearingUpdate(HearingUpdate.builder().hmcStatus(LISTED).build());
-    //    String stringMessage = OBJECT_MAPPER.writeValueAsString(hmcMessage);
-    //    byte[] message = StandardCharsets.UTF_8.encode(stringMessage).array();
-    //
-    //    given(mockObjectMapper.readValue(any(String.class), eq(HmcMessage.class))).willReturn(hmcMessage);
-    //    hmcHearingsEventTopicListener.onMessage(message);
-    //
-    //    verify(hmcMessageProcessor, never()).processMessage(any(HmcMessage.class));
-    //}
+    // Enable this test when batch processing is activated (and only EXCEPTION messages will be processed)
+    /*
+        @Test
+    public void should_not_process_messages_with_hmc_status_different_than_exception() throws Exception {
+        HmcMessage hmcMessage = TestUtils.createHmcMessage(SERVICE_CODE);
+        hmcMessage.setHearingUpdate(HearingUpdate.builder().hmcStatus(LISTED).build());
+        String stringMessage = OBJECT_MAPPER.writeValueAsString(hmcMessage);
+        byte[] message = StandardCharsets.UTF_8.encode(stringMessage).array();
+
+        given(mockObjectMapper.readValue(any(String.class), eq(HmcMessage.class))).willReturn(hmcMessage);
+        hmcHearingsEventTopicListener.onMessage(message);
+
+        verify(hmcMessageProcessor, never()).processMessage(any(HmcMessage.class));
+    }
+     */
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[https://tools.hmcts.net/jira/browse/RIA-8082](https://tools.hmcts.net/jira/browse/RIA-8082)


### Change description ###
- Commented out condition that used to exclude non-EXCEPTION messages for live processing (all messages being live processed again)
(temporary solution to unblock testing until batch processing works again)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
