### PR TITLE
RIA-8155 Added extra logging and changed HmcException

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateInterpreterDetailsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateInterpreterDetailsHandler.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.handlers.presubmit;
 
+import static java.util.Objects.requireNonNull;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -15,8 +17,6 @@ import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingsGetResponse
 import uk.gov.hmcts.reform.iahearingsapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iahearingsapi.domain.service.HearingService;
 import uk.gov.hmcts.reform.iahearingsapi.domain.service.UpdateHearingPayloadService;
-
-import static java.util.Objects.requireNonNull;
 
 @Component
 @Slf4j

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/EditListCaseHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/EditListCaseHandler.java
@@ -1,27 +1,5 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.handlers.servicedatahandlers;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.codec.binary.StringUtils;
-import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
-import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iahearingsapi.domain.entities.DynamicList;
-import uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre;
-import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ServiceData;
-import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.State;
-import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.DispatchPriority;
-import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.ServiceDataResponse;
-import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel;
-import uk.gov.hmcts.reform.iahearingsapi.domain.handlers.ServiceDataHandler;
-import uk.gov.hmcts.reform.iahearingsapi.domain.service.CoreCaseDataService;
-
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.List;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CHANNEL;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE;
@@ -36,6 +14,28 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.State.PRE_HE
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel.INTER;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel.TEL;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel.VID;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.DynamicList;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ServiceData;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.DispatchPriority;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.ServiceDataResponse;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel;
+import uk.gov.hmcts.reform.iahearingsapi.domain.handlers.ServiceDataHandler;
+import uk.gov.hmcts.reform.iahearingsapi.domain.service.CoreCaseDataService;
 
 @Slf4j
 @Component

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/HandlerUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/HandlerUtils.java
@@ -14,8 +14,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Objects;
-
-import org.apache.commons.codec.binary.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ServiceData;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel;

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/HearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/HearingService.java
@@ -162,6 +162,11 @@ public class HearingService {
             String serviceUserToken = idamService.getServiceUserToken();
             String serviceAuthToken = serviceAuthTokenGenerator.generate();
 
+            log.info("PUT updateHearingRequest by user with name: {}, uuid: {}, userRoles: {}",
+                     idamService.getUserInfo().getName(),
+                     idamService.getUserInfo().getUid(),
+                     idamService.getUserInfo().getRoles());
+
             return hmcHearingApi.updateHearingRequest(
                 serviceUserToken,
                 serviceAuthToken,
@@ -169,7 +174,7 @@ public class HearingService {
                 hearingId
             );
         } catch (FeignException ex) {
-            log.error("Failed to update hearing with Id: {} from HMC", hearingId);
+            log.error("Failed to update hearing with Id: {} from HMC. Error: {}", hearingId, ex.getMessage());
             throw new HmcException(ex);
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/exception/HmcException.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/exception/HmcException.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.iahearingsapi.infrastructure.exception;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 public class HmcException extends RuntimeException {
 
-    public static final String MESSAGE_TEMPLATE = "Failed to retrieve data from HMC";
+    public static final String MESSAGE_TEMPLATE = "Failed to retrieve data from HMC. Error: ";
 
     public HmcException(Throwable t) {
-        super(MESSAGE_TEMPLATE, t);
+        super(MESSAGE_TEMPLATE + defaultString(t.getMessage()), t);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/HearingExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/HearingExceptionHandlerTest.java
@@ -9,8 +9,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.HANDLE_HEARING_EXCEPTION;
 
+import com.github.dockerjava.api.exception.NotFoundException;
 import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +18,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.webjars.NotFoundException;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ServiceData;

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/HearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/HearingServiceTest.java
@@ -51,6 +51,7 @@ import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.HmcHearingApi;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.hmc.DeleteHearingRequest;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.hmc.HmcHearingRequestPayload;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.hmc.HmcHearingResponse;
+import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.idam.UserInfo;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.exception.HmcException;
 
 @ExtendWith(MockitoExtension.class)
@@ -92,6 +93,8 @@ class HearingServiceTest {
     private ReasonForLink reasonForLink;
     @Mock
     private Request request;
+    @Mock
+    private UserInfo userInfo;
     @InjectMocks
     private HearingService hearingService;
 
@@ -196,6 +199,10 @@ class HearingServiceTest {
 
     @Test
     void testUpdateHearing() {
+        when(idamService.getUserInfo()).thenReturn(userInfo);
+        when(userInfo.getName()).thenReturn("Name");
+        when(userInfo.getUid()).thenReturn("uuid");
+        when(userInfo.getRoles()).thenReturn(List.of("role1"));
         when(hmcHearingApi.updateHearingRequest(IDAM_OAUTH2_TOKEN, SERVICE_AUTHORIZATION, updateHearingRequest,
                                                 HEARING_ID
         )).thenReturn(new HearingGetResponse());
@@ -213,6 +220,10 @@ class HearingServiceTest {
 
     @Test
     void testUpdateHearingException() {
+        when(idamService.getUserInfo()).thenReturn(userInfo);
+        when(userInfo.getName()).thenReturn("Name");
+        when(userInfo.getUid()).thenReturn("uuid");
+        when(userInfo.getRoles()).thenReturn(List.of("role1"));
         when(idamService.getServiceUserToken()).thenReturn("serviceUserToken");
         when(serviceAuthTokenGenerator.generate()).thenReturn("serviceAuthToken");
         when(hmcHearingApi.updateHearingRequest(anyString(), anyString(), any(UpdateHearingRequest.class), anyString()))


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8155](https://tools.hmcts.net/jira/browse/RIA-8155)


### Change description ###
- Changed HmcException to retail the original message of the exception it wraps
- Extra logging for user details and the Feign exception thrown when updating hearing request

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
