### PR TITLE
RIA-8155 Default HearingWindowModel to null

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/hmc/HearingWindowModel.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/hmc/HearingWindowModel.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Objects;
+import java.util.stream.Stream;
 import lombok.Builder;
 import lombok.Data;
 
@@ -12,4 +14,11 @@ public class HearingWindowModel {
     private String dateRangeStart;
     private String dateRangeEnd;
     private String firstDateTimeMustBe;
+
+    public HearingWindowModel defaultIfNull() {
+        if (Stream.of(dateRangeStart, dateRangeEnd, firstDateTimeMustBe).anyMatch(Objects::nonNull)) {
+            return this;
+        }
+        return null;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/HearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/HearingService.java
@@ -162,11 +162,6 @@ public class HearingService {
             String serviceUserToken = idamService.getServiceUserToken();
             String serviceAuthToken = serviceAuthTokenGenerator.generate();
 
-            log.info("PUT updateHearingRequest by user with name: {}, uuid: {}, userRoles: {}",
-                     idamService.getUserInfo().getName(),
-                     idamService.getUserInfo().getUid(),
-                     idamService.getUserInfo().getRoles());
-
             return hmcHearingApi.updateHearingRequest(
                 serviceUserToken,
                 serviceAuthToken,

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadService.java
@@ -111,9 +111,9 @@ public class UpdateHearingPayloadService {
                                                    HearingGetResponse persistedHearing) {
         if (!firstAvailable) {
             if (hearingWindowModel == null) {
-                return persistedHearing.getHearingDetails().getHearingWindow();
+                return persistedHearing.getHearingDetails().getHearingWindow().defaultIfNull();
             } else {
-                return hearingWindowModel;
+                return hearingWindowModel.defaultIfNull();
             }
         }
         return null;

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/HearingWindowModelTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/HearingWindowModelTest.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.iahearingsapi.domain.entities;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingWindowModel;
+
+public class HearingWindowModelTest {
+
+    private static final String DATE_START = "dateStart";
+
+    @Test
+    void should_not_default_to_null_if_any_field_is_not_null() {
+        HearingWindowModel hearingWindowModel = HearingWindowModel
+            .builder()
+            .dateRangeStart(DATE_START)
+            .build();
+
+        assertNotNull(hearingWindowModel.defaultIfNull());
+    }
+
+    @Test
+    void should_default_to_null_if_all_fields_are_not_null() {
+        HearingWindowModel hearingWindowModel = HearingWindowModel
+            .builder()
+            .build();
+
+        assertNull(hearingWindowModel.defaultIfNull());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/HearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/HearingServiceTest.java
@@ -51,7 +51,6 @@ import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.HmcHearingApi;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.hmc.DeleteHearingRequest;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.hmc.HmcHearingRequestPayload;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.hmc.HmcHearingResponse;
-import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.idam.UserInfo;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.exception.HmcException;
 
 @ExtendWith(MockitoExtension.class)
@@ -93,8 +92,6 @@ class HearingServiceTest {
     private ReasonForLink reasonForLink;
     @Mock
     private Request request;
-    @Mock
-    private UserInfo userInfo;
     @InjectMocks
     private HearingService hearingService;
 
@@ -199,10 +196,6 @@ class HearingServiceTest {
 
     @Test
     void testUpdateHearing() {
-        when(idamService.getUserInfo()).thenReturn(userInfo);
-        when(userInfo.getName()).thenReturn("Name");
-        when(userInfo.getUid()).thenReturn("uuid");
-        when(userInfo.getRoles()).thenReturn(List.of("role1"));
         when(hmcHearingApi.updateHearingRequest(IDAM_OAUTH2_TOKEN, SERVICE_AUTHORIZATION, updateHearingRequest,
                                                 HEARING_ID
         )).thenReturn(new HearingGetResponse());
@@ -220,10 +213,6 @@ class HearingServiceTest {
 
     @Test
     void testUpdateHearingException() {
-        when(idamService.getUserInfo()).thenReturn(userInfo);
-        when(userInfo.getName()).thenReturn("Name");
-        when(userInfo.getUid()).thenReturn("uuid");
-        when(userInfo.getRoles()).thenReturn(List.of("role1"));
         when(idamService.getServiceUserToken()).thenReturn("serviceUserToken");
         when(serviceAuthTokenGenerator.generate()).thenReturn("serviceAuthToken");
         when(hmcHearingApi.updateHearingRequest(anyString(), anyString(), any(UpdateHearingRequest.class), anyString()))


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8155](https://tools.hmcts.net/jira/browse/RIA-8155)


### Change description ###
- Default `HearingWindowModel` to a null object if it's an object with all null fields (when updating hearing request)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
