### PR TITLE
RIA-8082 Disable live processing of messages

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListener.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.reform.iahearingsapi.infrastructure.hmc.listeners;
 
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.EXCEPTION;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jms.annotation.JmsListener;
@@ -52,10 +55,10 @@ public class HmcHearingsEventTopicListener {
                      caseId, hearingId);
 
             /*
-            Disallow messages other than EXCEPTION after batch processing gets enabled
-            Objects.equals(hmcMessage.getHearingUpdate().getHmcStatus(), EXCEPTION)
+            Batch-processing enabled: only EXCEPTION messages are processed live
              */
-            if (isMessageRelevantForService(hmcMessage)) {
+            if (isMessageRelevantForService(hmcMessage)
+                && Objects.equals(hmcMessage.getHearingUpdate().getHmcStatus(), EXCEPTION)) {
 
                 log.info("Attempting to process message from HMC hearings topic for"
                              + " Case ID {}, and Hearing ID {} with status EXCEPTION", caseId, hearingId);

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/listeners/HmcHearingsEventTopicListenerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.EXCEPTION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.LISTED;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
@@ -70,9 +71,8 @@ class HmcHearingsEventTopicListenerTest {
         verify(hmcMessageProcessor, never()).processMessage(any(HmcMessage.class));
     }
 
-    // Enable this test when batch processing is activated (and only EXCEPTION messages will be processed)
-    /*
-        @Test
+    // Disable this test if using live-processing instead of batch-processing of messages
+    @Test
     public void should_not_process_messages_with_hmc_status_different_than_exception() throws Exception {
         HmcMessage hmcMessage = TestUtils.createHmcMessage(SERVICE_CODE);
         hmcMessage.setHearingUpdate(HearingUpdate.builder().hmcStatus(LISTED).build());
@@ -84,6 +84,5 @@ class HmcHearingsEventTopicListenerTest {
 
         verify(hmcMessageProcessor, never()).processMessage(any(HmcMessage.class));
     }
-     */
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[https://tools.hmcts.net/jira/browse/RIA-8082](https://tools.hmcts.net/jira/browse/RIA-8082)


### Change description ###
- Reverted the changes that disabled batch-processing, which can be re-enabled now


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
