### PR TITLE
RIA-8093 - Added respondent into the count of attendees

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProvider.java
@@ -299,12 +299,12 @@ public class ServiceHearingValuesProvider {
     }
 
     public int getNumberOfPhysicalAttendees(List<PartyDetailsModel> partyDetails) {
-
+        // Plus one to include respondent (Home Office) which is an ORG type party
         return (int) partyDetails.stream()
             .filter(party -> party.getIndividualDetails() != null
                              && StringUtils.equals(
                                  party.getIndividualDetails().getPreferredHearingChannel(),
                                  IN_PERSON))
-            .count();
+            .count() + 1;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProviderTest.java
@@ -286,7 +286,7 @@ class ServiceHearingValuesProviderTest {
             .hearingWindow(hearingWindowModel)
             .duration(Integer.parseInt(listCaseHearingLength))
             .hearingPriorityType(PriorityType.STANDARD)
-            .numberOfPhysicalAttendees(0)
+            .numberOfPhysicalAttendees(1)
             .hearingInWelshFlag(false)
             .hearingLocations(Collections.emptyList())
             .facilitiesRequired(Collections.emptyList())
@@ -370,7 +370,7 @@ class ServiceHearingValuesProviderTest {
 
         int expectedPartiesInPerson = serviceHearingValuesProvider.getNumberOfPhysicalAttendees(partyDetails);
 
-        assertEquals(expectedPartiesInPerson, 2);
+        assertEquals(expectedPartiesInPerson, 3);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RIA-8093

For S5 numberOfPhysicalAttendees population logic takes Home Office in to account



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
