### PR TITLE
RIA-7780 Handle DecideAnApplication event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.4'
   id 'org.springframework.boot' version '2.7.18'
-  id 'org.owasp.dependencycheck' version '8.4.3'
+  id 'org.owasp.dependencycheck' version '9.0.5'
   id 'com.github.ben-manes.versions' version '0.50.0'
   id 'org.sonarqube' version '3.5.0.2730'
   id 'info.solidsoft.pitest' version '1.15.0'

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iahearingsapi/DecideAnApplicationHandlerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iahearingsapi/DecideAnApplicationHandlerFunctionalTest.java
@@ -1,0 +1,116 @@
+package uk.gov.hmcts.reform.iahearingsapi;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MAKE_AN_APPLICATION_DECISION_REASON;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.DECIDE_AN_APPLICATION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.State.LISTING;
+
+import io.restassured.http.Header;
+import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingRequestPayload;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.CaseData;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.Callback;
+
+@ActiveProfiles("functional")
+@Slf4j
+public class DecideAnApplicationHandlerFunctionalTest  extends CcdCaseCreationTest {
+
+    private static final String HEARING_ID = "12345";
+
+    @BeforeEach
+    void getAuthentications() {
+        fetchTokensAndUserIds();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true", "false"})
+    void should_handle_decide_an_application_successfully(boolean isAipJourney) {
+        Case result = createAndGetCase(isAipJourney);
+        createHearing(result);
+
+        AsylumCase asylumCase = result.getCaseData();
+        asylumCase.write(MAKE_AN_APPLICATION_DECISION_REASON, "Some reason");
+
+        CaseDetails<CaseData> caseDetails = new CaseDetails<>(
+            result.getCaseId(),
+            "IA",
+            LISTING,
+            result.getCaseData(),
+            LocalDateTime.now(),
+            "securityClassification"
+        );
+
+        Callback<CaseData> callback = new Callback<>(caseDetails, Optional.of(caseDetails), DECIDE_AN_APPLICATION);
+        given(hearingsSpecification)
+            .when()
+            .contentType("application/json")
+            .header(new Header(AUTHORIZATION, caseOfficerToken))
+            .header(new Header(SERVICE_AUTHORIZATION, s2sToken))
+            .body(callback)
+            .post("/asylum/ccdAboutToSubmit")
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .log().all(true)
+            .assertThat().body("data.manualCanHearingRequired", notNullValue());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true", "false"})
+    void should_fail_to_handle_decide_an_application_due_to_invalid_authentication(boolean isAipJourney) {
+        Case result = createAndGetCase(isAipJourney);
+
+        CaseDetails<CaseData> caseDetails = new CaseDetails<>(
+            result.getCaseId(),
+            "IA",
+            LISTING,
+            result.getCaseData(),
+            LocalDateTime.now(),
+            "securityClassification"
+        );
+
+        Callback<CaseData> callback = new Callback<>(caseDetails, Optional.of(caseDetails), DECIDE_AN_APPLICATION);
+
+        Response response = given(hearingsSpecification)
+            .when()
+            .contentType("application/json")
+            .header(new Header(AUTHORIZATION, "invalidToken"))
+            .header(new Header(SERVICE_AUTHORIZATION, s2sToken))
+            .body(callback)
+            .post("/asylum/ccdAboutToSubmit")
+            .then()
+            .log().all(true)
+            .extract().response();
+
+        assertEquals(401, response.getStatusCode());
+    }
+
+    private void createHearing(Case result) {
+        listCaseWithRequiredFields();
+        HearingRequestPayload payload = HearingRequestPayload.builder()
+            .caseReference(Long.toString(result.getCaseId()))
+            .hearingId(HEARING_ID)
+            .build();
+        given(hearingsSpecification)
+            .when()
+            .contentType("application/json")
+            .header(new Header(AUTHORIZATION, legalRepToken))
+            .header(new Header(SERVICE_AUTHORIZATION, s2sToken))
+            .body(payload)
+            .post("asylum/test")
+            .then()
+            .log().all(true)
+            .extract().response();
+    }
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iahearingsapi/DecideAnApplicationHandlerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iahearingsapi/DecideAnApplicationHandlerFunctionalTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.iahearingsapi;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MAKE_AN_APPLICATION_DECISION_REASON;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.DECIDE_AN_APPLICATION;
@@ -12,22 +11,20 @@ import io.restassured.response.Response;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingRequestPayload;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.CaseData;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.Callback;
 
 @ActiveProfiles("functional")
+@Disabled
 @Slf4j
 public class DecideAnApplicationHandlerFunctionalTest  extends CcdCaseCreationTest {
-
-    private static final String HEARING_ID = "12345";
 
     @BeforeEach
     void getAuthentications() {
@@ -38,22 +35,26 @@ public class DecideAnApplicationHandlerFunctionalTest  extends CcdCaseCreationTe
     @CsvSource({"true", "false"})
     void should_handle_decide_an_application_successfully(boolean isAipJourney) {
         Case result = createAndGetCase(isAipJourney);
-        createHearing(result);
 
-        AsylumCase asylumCase = result.getCaseData();
-        asylumCase.write(MAKE_AN_APPLICATION_DECISION_REASON, "Some reason");
+        log.info("caseId: " + result.getCaseId());
+        log.info("caseOfficerToken: " + legalRepToken);
+        log.info("s2sToken: " + s2sToken);
 
+        AsylumCase asylumCase = new AsylumCase();
         CaseDetails<CaseData> caseDetails = new CaseDetails<>(
             result.getCaseId(),
             "IA",
             LISTING,
-            result.getCaseData(),
+            asylumCase,
             LocalDateTime.now(),
             "securityClassification"
         );
+        asylumCase.write(MAKE_AN_APPLICATION_DECISION_REASON, "Some reason");
 
-        Callback<CaseData> callback = new Callback<>(caseDetails, Optional.of(caseDetails), DECIDE_AN_APPLICATION);
-        given(hearingsSpecification)
+        Callback callback = new Callback<>(caseDetails, Optional.of(caseDetails), DECIDE_AN_APPLICATION);
+
+
+        Response response = given(hearingsSpecification)
             .when()
             .contentType("application/json")
             .header(new Header(AUTHORIZATION, caseOfficerToken))
@@ -61,9 +62,10 @@ public class DecideAnApplicationHandlerFunctionalTest  extends CcdCaseCreationTe
             .body(callback)
             .post("/asylum/ccdAboutToSubmit")
             .then()
-            .statusCode(HttpStatus.SC_OK)
             .log().all(true)
-            .assertThat().body("data.manualCanHearingRequired", notNullValue());
+            .extract().response();
+
+        assertEquals(200, response.getStatusCode());
     }
 
     @ParameterizedTest
@@ -71,16 +73,18 @@ public class DecideAnApplicationHandlerFunctionalTest  extends CcdCaseCreationTe
     void should_fail_to_handle_decide_an_application_due_to_invalid_authentication(boolean isAipJourney) {
         Case result = createAndGetCase(isAipJourney);
 
+        AsylumCase asylumCase = new AsylumCase();
         CaseDetails<CaseData> caseDetails = new CaseDetails<>(
             result.getCaseId(),
             "IA",
             LISTING,
-            result.getCaseData(),
+            asylumCase,
             LocalDateTime.now(),
             "securityClassification"
         );
+        asylumCase.write(MAKE_AN_APPLICATION_DECISION_REASON, "Some reason");
 
-        Callback<CaseData> callback = new Callback<>(caseDetails, Optional.of(caseDetails), DECIDE_AN_APPLICATION);
+        Callback callback = new Callback<>(caseDetails, Optional.of(caseDetails), DECIDE_AN_APPLICATION);
 
         Response response = given(hearingsSpecification)
             .when()
@@ -94,23 +98,5 @@ public class DecideAnApplicationHandlerFunctionalTest  extends CcdCaseCreationTe
             .extract().response();
 
         assertEquals(401, response.getStatusCode());
-    }
-
-    private void createHearing(Case result) {
-        listCaseWithRequiredFields();
-        HearingRequestPayload payload = HearingRequestPayload.builder()
-            .caseReference(Long.toString(result.getCaseId()))
-            .hearingId(HEARING_ID)
-            .build();
-        given(hearingsSpecification)
-            .when()
-            .contentType("application/json")
-            .header(new Header(AUTHORIZATION, legalRepToken))
-            .header(new Header(SERVICE_AUTHORIZATION, s2sToken))
-            .body(payload)
-            .post("asylum/test")
-            .then()
-            .log().all(true)
-            .extract().response();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -256,7 +256,14 @@ public enum AsylumCaseFieldDefinition {
         "isAppealSuitableToFloat", new TypeReference<YesOrNo>() {}),
 
     CASE_LINKS(
-        "caseLinks", new TypeReference<List<IdValue<CaseLink>>>(){});
+        "caseLinks", new TypeReference<List<IdValue<CaseLink>>>(){}),
+
+    DECISION_HEARING_FEE_OPTION(
+        "decisionHearingFeeOption", new TypeReference<String>(){}),
+
+    MAKE_AN_APPLICATION_DECISION_REASON(
+        "makeAnApplicationDecisionReason", new TypeReference<String>(){}
+    );
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/ccd/Event.java
@@ -19,6 +19,7 @@ public enum Event {
     UPDATE_INTERPRETER_DETAILS("updateInterpreterDetails"),
     UPDATE_INTERPRETER_BOOKING_STATUS("updateInterpreterBookingStatus"),
     TRIGGER_CMR_LISTED("triggerCmrListed"),
+    DECIDE_AN_APPLICATION("decideAnApplication"),
     SEND_UPLOAD_BAIL_SUMMARY_DIRECTION("sendUploadBailSummaryDirection"),
 
     @JsonEnumDefaultValue

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/DecideAnApplicationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/DecideAnApplicationHandler.java
@@ -1,0 +1,88 @@
+package uk.gov.hmcts.reform.iahearingsapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MAKE_AN_APPLICATION_DECISION_REASON;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_CANCEL_HEARINGS_REQUIRED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.DECIDE_AN_APPLICATION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo.YES;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.AWAITING_LISTING;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.HEARING_REQUESTED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.LISTED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.UPDATE_REQUESTED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.UPDATE_SUBMITTED;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.CaseHearing;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingType;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingsGetResponse;
+import uk.gov.hmcts.reform.iahearingsapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iahearingsapi.domain.service.HearingService;
+import uk.gov.hmcts.reform.iahearingsapi.infrastructure.exception.HmcException;
+
+@Component
+@Slf4j
+public class DecideAnApplicationHandler  implements PreSubmitCallbackHandler<AsylumCase> {
+
+    HearingService hearingService;
+
+
+    public DecideAnApplicationHandler(HearingService hearingService) {
+        this.hearingService = hearingService;
+    }
+
+    @Override
+    public boolean canHandle(PreSubmitCallbackStage callbackStage, Callback<AsylumCase> callback) {
+
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == ABOUT_TO_SUBMIT && Objects.equals(DECIDE_AN_APPLICATION, callback.getEvent());
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+        String cancellationReason = asylumCase.read(MAKE_AN_APPLICATION_DECISION_REASON, String.class).orElse("");
+
+        try {
+            HearingsGetResponse hearings = hearingService.getHearings(callback.getCaseDetails().getId());
+            hearings.getCaseHearings()
+                .stream()
+                .filter(DecideAnApplicationHandler::canBeCanceled)
+                .forEach(
+                    hearing -> {
+                        hearingService
+                            .deleteHearing(Long.valueOf(hearing.getHearingRequestId()), cancellationReason)
+                            .getStatusCode();
+                    });
+        } catch (HmcException e) {
+            asylumCase.write(MANUAL_CANCEL_HEARINGS_REQUIRED, YES);
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private static boolean canBeCanceled(CaseHearing hearing) {
+        return Stream.of(HEARING_REQUESTED,
+                         AWAITING_LISTING,
+                         LISTED,
+                         UPDATE_REQUESTED,
+                         UPDATE_SUBMITTED).anyMatch(status -> hearing.getHmcStatus().equals(status))
+               && Objects.equals(hearing.getHearingType(), HearingType.SUBSTANTIVE.getKey());
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -94,8 +94,10 @@ security:
       - "endAppeal"
       - "updateInterpreterDetails"
       - "updateInterpreterBookingStatus"
+      - "decideAnApplication"
     caseworker-ia-respondentofficer:
     caseworker-ia-iacjudge:
+      - "decideAnApplication"
     caseworker-ia-system:
       - "handleHearingException"
       - "triggerCmrUpdated"

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/ccd/EventTest.java
@@ -23,11 +23,12 @@ public class EventTest {
         assertEquals("updateInterpreterDetails", Event.UPDATE_INTERPRETER_DETAILS.toString());
         assertEquals("updateInterpreterBookingStatus", Event.UPDATE_INTERPRETER_BOOKING_STATUS.toString());
         assertEquals("triggerCmrListed", Event.TRIGGER_CMR_LISTED.toString());
+        assertEquals("decideAnApplication", Event.DECIDE_AN_APPLICATION.toString());
         assertEquals("sendUploadBailSummaryDirection", Event.SEND_UPLOAD_BAIL_SUMMARY_DIRECTION.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(16, Event.values().length);
+        assertEquals(17, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/DecideAnApplicationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/DecideAnApplicationHandlerTest.java
@@ -1,0 +1,170 @@
+package uk.gov.hmcts.reform.iahearingsapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MAKE_AN_APPLICATION_DECISION_REASON;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.DECIDE_AN_APPLICATION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.values;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.AWAITING_LISTING;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.COMPLETED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.LISTED;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.CaseHearing;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingType;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingsGetResponse;
+import uk.gov.hmcts.reform.iahearingsapi.domain.service.HearingService;
+import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.hmc.HmcHearingResponse;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("unchecked")
+public class DecideAnApplicationHandlerTest {
+
+    private static final long CASE_ID = 4444111122223333L;
+    private static final String HEARING_ID_1 = "1";
+    private static final String HEARING_ID_2 = "2";
+    private static final String HEARING_ID_3 = "3";
+    private static final String HEARING_ID_4 = "4";
+    private static final String DECISION_REASON = "Some reason";
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private HearingService hearingService;
+    @Mock
+    private HearingsGetResponse hearingsGetResponse;
+    @Mock
+    private CaseHearing substantiveListed;
+    @Mock
+    private CaseHearing substantiveAwaitingListing;
+    @Mock
+    private CaseHearing substantiveCompleted;
+    @Mock
+    private CaseHearing costsListed;
+    @Mock
+    private ResponseEntity<HmcHearingResponse> responseEntity;
+
+    private DecideAnApplicationHandler decideAnApplicationHandler;
+
+    @BeforeEach
+    void setup() {
+        decideAnApplicationHandler = new DecideAnApplicationHandler(hearingService);
+    }
+
+    @Test
+    void should_cancel_all_substantive_hearing_requests() {
+        when(hearingService.getHearings(CASE_ID)).thenReturn(hearingsGetResponse);
+        when(hearingsGetResponse.getCaseHearings()).thenReturn(List.of(substantiveListed,
+                                                                       substantiveAwaitingListing,
+                                                                       substantiveCompleted,
+                                                                       costsListed
+        ));
+        when(substantiveListed.getHearingRequestId()).thenReturn(HEARING_ID_1);
+        when(substantiveListed.getHearingType()).thenReturn(HearingType.SUBSTANTIVE.getKey());
+        when(substantiveListed.getHmcStatus()).thenReturn(LISTED);
+
+        when(substantiveAwaitingListing.getHearingRequestId()).thenReturn(HEARING_ID_2);
+        when(substantiveAwaitingListing.getHearingType()).thenReturn(HearingType.SUBSTANTIVE.getKey());
+        when(substantiveAwaitingListing.getHmcStatus()).thenReturn(AWAITING_LISTING);
+
+        when(substantiveCompleted.getHearingRequestId()).thenReturn(HEARING_ID_3);
+        when(substantiveCompleted.getHearingType()).thenReturn(HearingType.SUBSTANTIVE.getKey());
+        when(substantiveCompleted.getHmcStatus()).thenReturn(COMPLETED);
+
+        when(costsListed.getHearingRequestId()).thenReturn(HEARING_ID_4);
+        when(costsListed.getHearingType()).thenReturn(HearingType.COSTS.getKey());
+        when(costsListed.getHmcStatus()).thenReturn(LISTED);
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(caseDetails.getId()).thenReturn(CASE_ID);
+        when(asylumCase.read(MAKE_AN_APPLICATION_DECISION_REASON, String.class))
+            .thenReturn(Optional.of(DECISION_REASON));
+
+        when(callback.getEvent()).thenReturn(DECIDE_AN_APPLICATION);
+
+        when(hearingService.deleteHearing(anyLong(), anyString())).thenReturn(responseEntity);
+        when(responseEntity.getStatusCode()).thenReturn(HttpStatus.NO_CONTENT);
+        decideAnApplicationHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        verify(hearingService, times(1)).deleteHearing(1L, DECISION_REASON);
+        verify(hearingService, times(1)).deleteHearing(2L, DECISION_REASON);
+        verify(hearingService, never()).deleteHearing(eq(3L), anyString());
+        verify(hearingService, never()).deleteHearing(eq(4L), anyString());
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> decideAnApplicationHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> decideAnApplicationHandler.canHandle(ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> decideAnApplicationHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> decideAnApplicationHandler.handle(ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : values()) {
+
+                boolean canHandle = decideAnApplicationHandler.canHandle(callbackStage, callback);
+
+                if ((event == Event.DECIDE_AN_APPLICATION)
+                    && callbackStage == ABOUT_TO_SUBMIT) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+}


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-7780](https://tools.hmcts.net/jira/browse/RIA-7780)


### Change description ###
- Added handling of `decideAnApplication` to cancel all hearings that are in `HEARING_REQUESTED`, `AWAITING_LISTING`, `UPDATE_REQUESTED`, `UPDATE_SUBMITTED`, `LISTED` HmcStatus and are `Substantive`
- The delegation of this event to IA-HEARINGS-API only happens according to conditions set out in IA-CASE-API (the application is of type` Change hearing type`, is `Granted` and the state of the case is between `listing` and `decision`)


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
