### PR TITLE
RIA-8006 Interpreter booking statuses added to other reasonable adjs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/BailCaseFieldDefinition.java
@@ -106,7 +106,27 @@ public enum BailCaseFieldDefinition {
     SUPPORTER_4_MOBILE_NUMBER_1(
         "supporter4MobileNumber1", new TypeReference<String>(){}),
     SUPPORTER_4_EMAIL_ADDRESS_1(
-        "supporter4EmailAddress1", new TypeReference<String>(){}),;
+        "supporter4EmailAddress1", new TypeReference<String>(){}),
+    APPLICANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS(
+        "applicantInterpreterSpokenLanguageBookingStatus", new TypeReference<InterpreterBookingStatus>(){}),
+    APPLICANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS(
+        "applicantInterpreterSignLanguageBookingStatus", new TypeReference<InterpreterBookingStatus>(){}),
+    FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_1(
+        "fcsInterpreterSpokenLanguageBookingStatus1", new TypeReference<InterpreterBookingStatus>(){}),
+    FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_2(
+        "fcsInterpreterSpokenLanguageBookingStatus2", new TypeReference<InterpreterBookingStatus>(){}),
+    FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_3(
+        "fcsInterpreterSpokenLanguageBookingStatus3", new TypeReference<InterpreterBookingStatus>(){}),
+    FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_4(
+        "fcsInterpreterSpokenLanguageBookingStatus4", new TypeReference<InterpreterBookingStatus>(){}),
+    FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_1(
+        "fcsInterpreterSignLanguageBookingStatus1", new TypeReference<InterpreterBookingStatus>(){}),
+    FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_2(
+        "fcsInterpreterSignLanguageBookingStatus2", new TypeReference<InterpreterBookingStatus>(){}),
+    FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_3(
+        "fcsInterpreterSignLanguageBookingStatus3", new TypeReference<InterpreterBookingStatus>(){}),
+    FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_4(
+        "fcsInterpreterSignLanguageBookingStatus4", new TypeReference<InterpreterBookingStatus>(){}),;
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/ApplicantDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/ApplicantDetailsMapper.java
@@ -1,16 +1,21 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.mappers.bail;
 
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.PartyDetailsMapper.appendBookingStatus;
+
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.CustodyStatus;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.IndividualDetailsModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyDetailsModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyType;
 import uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper;
-
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_FAMILY_NAME;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES;
 
 @Component
 @AllArgsConstructor
@@ -42,6 +47,21 @@ public class ApplicantDetailsMapper {
 
         languageAndAdjustmentsMapper.processBailPartyCaseFlags(bailCase, applicantPartyDetailsModel);
 
+        appendApplicantBookingStatus(bailCase, applicantPartyDetailsModel);
+
         return applicantPartyDetailsModel;
+    }
+
+    private void appendApplicantBookingStatus(BailCase bailCase,
+                                              PartyDetailsModel applicantPartyDetailsModel) {
+
+        Optional<InterpreterBookingStatus> spokenBookingStatus = bailCase
+            .read(BailCaseFieldDefinition.APPLICANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS,
+                InterpreterBookingStatus.class);
+
+        Optional<InterpreterBookingStatus> signBookingStatus = bailCase
+            .read(APPLICANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class);
+
+        appendBookingStatus(spokenBookingStatus, signBookingStatus, applicantPartyDetailsModel);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/FinancialConditionSupporterDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/FinancialConditionSupporterDetailsMapper.java
@@ -2,10 +2,12 @@ package uk.gov.hmcts.reform.iahearingsapi.domain.mappers.bail;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.IndividualDetailsModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyDetailsModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyType;
@@ -39,7 +41,10 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDef
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.SUPPORTER_GIVEN_NAMES;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.SUPPORTER_MOBILE_NUMBER_1;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.SUPPORTER_TELEPHONE_NUMBER_1;
-
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus.NOT_REQUESTED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.mappers.PartyDetailsMapper.appendBookingStatus;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.utils.InterpreterLanguagesUtils.FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUSES;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.utils.InterpreterLanguagesUtils.FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUSES;
 
 @Component
 @AllArgsConstructor
@@ -123,6 +128,8 @@ public class FinancialConditionSupporterDetailsMapper {
                 languageAndAdjustmentsMapper.processBailPartyCaseFlags(bailCase, fcsPartyDetailsModel);
 
                 fcsDetailsList.add(fcsPartyDetailsModel);
+
+                appendFcsBookingStatus(bailCase, fcsPartyDetailsModel, i);
             }
             i++;
         }
@@ -141,4 +148,22 @@ public class FinancialConditionSupporterDetailsMapper {
         }
         return phoneNumber;
     }
+
+    private void appendFcsBookingStatus(BailCase bailCase,
+                                        PartyDetailsModel fcsPartyDetailsModel,
+                                        int index) {
+
+        Optional<InterpreterBookingStatus> spokenBookingStatus = bailCase
+            .read(FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUSES.get(index), InterpreterBookingStatus.class)
+            .filter(interpreterBookingStatus -> !interpreterBookingStatus.equals(NOT_REQUESTED));
+
+        Optional<InterpreterBookingStatus> signBookingStatus = bailCase
+            .read(FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUSES.get(index), InterpreterBookingStatus.class)
+            .filter(interpreterBookingStatus -> !interpreterBookingStatus.equals(NOT_REQUESTED));
+
+        appendBookingStatus(spokenBookingStatus, signBookingStatus, fcsPartyDetailsModel);
+    }
+
+
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/InterpreterLanguagesUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/InterpreterLanguagesUtils.java
@@ -20,9 +20,18 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_7;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_8;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_9;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_1;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_2;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_3;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_4;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_1;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_2;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_3;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_4;
 
 import java.util.List;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition;
 
 public class InterpreterLanguagesUtils {
 
@@ -50,5 +59,19 @@ public class InterpreterLanguagesUtils {
         WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_8,
         WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_9,
         WITNESS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_10
+    );
+
+    public static final List<BailCaseFieldDefinition> FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUSES = List.of(
+        FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_1,
+        FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_2,
+        FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_3,
+        FCS_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS_4
+    );
+
+    public static final List<BailCaseFieldDefinition> FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUSES = List.of(
+        FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_1,
+        FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_2,
+        FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_3,
+        FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_4
     );
 }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/ApplicantDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/ApplicantDetailsMapperTest.java
@@ -1,19 +1,27 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.mappers.bail;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.InterpreterBookingStatus;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.IndividualDetailsModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.PartyDetailsModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.mappers.LanguageAndAdjustmentsMapper;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS;
 
 @ExtendWith(MockitoExtension.class)
 class ApplicantDetailsMapperTest {
@@ -30,14 +38,13 @@ class ApplicantDetailsMapperTest {
     @BeforeEach
     void setup() {
         when(caseDataMapper.getApplicantPartyId(bailCase)).thenReturn("partyId");
+        when(caseFlagsMapper.getVulnerableDetails(bailCase)).thenReturn("vulnerability details");
+        when(caseFlagsMapper.getVulnerableFlag(bailCase)).thenReturn(true);
+        when(caseDataMapper.getHearingChannel(bailCase)).thenReturn("VID");
     }
 
     @Test
     void should_map_correctly() {
-
-        when(caseFlagsMapper.getVulnerableDetails(bailCase)).thenReturn("vulnerability details");
-        when(caseFlagsMapper.getVulnerableFlag(bailCase)).thenReturn(true);
-        when(caseDataMapper.getHearingChannel(bailCase)).thenReturn("VID");
 
         IndividualDetailsModel individualDetails = IndividualDetailsModel.builder()
             .custodyStatus("D")
@@ -49,9 +56,103 @@ class ApplicantDetailsMapperTest {
         when(languageAndAdjustmentsMapper.processBailPartyCaseFlags(eq(bailCase), any(PartyDetailsModel.class)))
             .thenReturn(expected);
 
-        expected.getIndividualDetails().setOtherReasonableAdjustmentDetails(null);
+        expected.getIndividualDetails().setOtherReasonableAdjustmentDetails("");
 
         assertEquals(expected, new ApplicantDetailsMapper(languageAndAdjustmentsMapper)
+            .map(bailCase, caseFlagsMapper, caseDataMapper));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = InterpreterBookingStatus.class, names = {"BOOKED", "REQUESTED", "CANCELLED", "NOT_REQUESTED"})
+    void should_handle_spoken_interpreter_booking_status(InterpreterBookingStatus bookingStatus) {
+        when(bailCase.read(APPLICANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class))
+            .thenReturn(Optional.of(bookingStatus));
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS,
+            InterpreterBookingStatus.class))
+            .thenReturn(Optional.empty());
+
+        IndividualDetailsModel individualDetails = IndividualDetailsModel.builder()
+            .custodyStatus("D")
+            .vulnerabilityDetails("vulnerability details")
+            .vulnerableFlag(true)
+            .preferredHearingChannel("VID")
+            .build();
+        PartyDetailsModel applicantPartyDetailsModel = getPartyDetailsModelForApplicant(individualDetails);
+        when(languageAndAdjustmentsMapper.processBailPartyCaseFlags(eq(bailCase), any(PartyDetailsModel.class)))
+            .thenReturn(applicantPartyDetailsModel);
+
+        String status = bookingStatus != InterpreterBookingStatus.NOT_REQUESTED
+            ? " Status: " + bookingStatus.getDesc() + ";"
+            : "";
+
+        applicantPartyDetailsModel.getIndividualDetails().setOtherReasonableAdjustmentDetails(
+            ((requireNonNullElse(applicantPartyDetailsModel.getIndividualDetails()
+                    .getOtherReasonableAdjustmentDetails(),
+                "") + status).trim()));
+
+        assertEquals(applicantPartyDetailsModel, new ApplicantDetailsMapper(languageAndAdjustmentsMapper)
+            .map(bailCase, caseFlagsMapper, caseDataMapper));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = InterpreterBookingStatus.class, names = {"BOOKED", "REQUESTED", "CANCELLED", "NOT_REQUESTED"})
+    void should_handle_sign_interpreter_booking_status(InterpreterBookingStatus bookingStatus) {
+        when(bailCase.read(APPLICANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class))
+            .thenReturn(Optional.empty());
+        when(bailCase.read(APPLICANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class))
+            .thenReturn(Optional.of(bookingStatus));
+
+        IndividualDetailsModel individualDetails = IndividualDetailsModel.builder()
+            .custodyStatus("D")
+            .vulnerabilityDetails("vulnerability details")
+            .vulnerableFlag(true)
+            .preferredHearingChannel("VID")
+            .build();
+        PartyDetailsModel applicantPartyDetailsModel = getPartyDetailsModelForApplicant(individualDetails);
+        when(languageAndAdjustmentsMapper.processBailPartyCaseFlags(eq(bailCase), any(PartyDetailsModel.class)))
+            .thenReturn(applicantPartyDetailsModel);
+
+        String status = bookingStatus != InterpreterBookingStatus.NOT_REQUESTED
+            ? " Status: " + bookingStatus.getDesc() + ";"
+            : "";
+
+        applicantPartyDetailsModel.getIndividualDetails().setOtherReasonableAdjustmentDetails(
+            ((requireNonNullElse(applicantPartyDetailsModel.getIndividualDetails()
+                    .getOtherReasonableAdjustmentDetails(),
+                "") + status).trim()));
+
+        assertEquals(applicantPartyDetailsModel, new ApplicantDetailsMapper(languageAndAdjustmentsMapper)
+            .map(bailCase, caseFlagsMapper, caseDataMapper));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = InterpreterBookingStatus.class, names = {"BOOKED", "REQUESTED", "CANCELLED", "NOT_REQUESTED"})
+    void should_handle_both_spoken_and_sign_interpreter_booking_status(InterpreterBookingStatus bookingStatus) {
+        when(bailCase.read(APPLICANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class))
+            .thenReturn(Optional.of(bookingStatus));
+        when(bailCase.read(APPLICANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS, InterpreterBookingStatus.class))
+            .thenReturn(Optional.of(bookingStatus));
+
+        IndividualDetailsModel individualDetails = IndividualDetailsModel.builder()
+            .custodyStatus("D")
+            .vulnerabilityDetails("vulnerability details")
+            .vulnerableFlag(true)
+            .preferredHearingChannel("VID")
+            .build();
+        PartyDetailsModel applicantPartyDetailsModel = getPartyDetailsModelForApplicant(individualDetails);
+        when(languageAndAdjustmentsMapper.processBailPartyCaseFlags(eq(bailCase), any(PartyDetailsModel.class)))
+            .thenReturn(applicantPartyDetailsModel);
+
+        String status = bookingStatus != InterpreterBookingStatus.NOT_REQUESTED
+            ? " Status (Spoken): " + bookingStatus.getDesc() + "; Status (Sign): " + bookingStatus.getDesc() + ";"
+            : "";
+
+        applicantPartyDetailsModel.getIndividualDetails().setOtherReasonableAdjustmentDetails(
+            ((requireNonNullElse(applicantPartyDetailsModel.getIndividualDetails()
+                    .getOtherReasonableAdjustmentDetails(),
+                "") + status).trim()));
+
+        assertEquals(applicantPartyDetailsModel, new ApplicantDetailsMapper(languageAndAdjustmentsMapper)
             .map(bailCase, caseFlagsMapper, caseDataMapper));
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-8006

### Change description ###

- Added booking status of interpreters (spoken and sign) to otherReasonableAdjustmentsDetails of individual details for each party (FCS and applicant)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
