### PR TITLE
RIA-8092 Make hearingWindow have a start date 28 working days later

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/BailCaseFieldDefinition.java
@@ -132,7 +132,9 @@ public enum BailCaseFieldDefinition {
     SEND_DIRECTION_LIST(
         "sendDirectionList", new TypeReference<String>(){}),
     DATE_OF_COMPLIANCE(
-        "dateOfCompliance", new TypeReference<String>(){});
+        "dateOfCompliance", new TypeReference<String>(){}),
+    CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER(
+        "currentCaseStateVisibleToAdminOfficer", new TypeReference<String>(){});
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/BailCaseDataToServiceHearingValuesMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/BailCaseDataToServiceHearingValuesMapper.java
@@ -1,5 +1,17 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.mappers.bail;
 
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DISABILITY1;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DISABILITY_DETAILS;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DOCUMENTS_WITH_METADATA;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_PARTY_ID;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_COMPANY;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_INDIVIDUAL_PARTY_ID;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_ORGANISATION_PARTY_ID;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.VIDEO_HEARING1;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.DocumentTag.BAIL_SUBMISSION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel.VID;
+
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -16,23 +28,13 @@ import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingWindowModel;
 
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DISABILITY1;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DISABILITY_DETAILS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DOCUMENTS_WITH_METADATA;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_PARTY_ID;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_COMPANY;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_INDIVIDUAL_PARTY_ID;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_ORGANISATION_PARTY_ID;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.VIDEO_HEARING1;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.DocumentTag.BAIL_SUBMISSION;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel.VID;
-
 @Service
 @RequiredArgsConstructor
 public class BailCaseDataToServiceHearingValuesMapper {
     static final int HEARING_START_WINDOW_INTERVAL_DEFAULT = 2;
     static final int HEARING_WINDOW_END_INTERVAL_DEFAULT = 7;
+    static final int HEARING_START_WINDOW_INTERVAL_CONDITIONAL_BAIL = 28;
+    static final String BAIL_STATE_DECISION_CONDITIONAL_BAIL = "decisionConditionalBail";
 
     private final DateProvider hearingServiceDateProvider;
 
@@ -54,18 +56,26 @@ public class BailCaseDataToServiceHearingValuesMapper {
         return "";
     }
 
-    public HearingWindowModel getHearingWindowModel() {
+    public HearingWindowModel getHearingWindowModel(String bailState) {
         ZonedDateTime now = hearingServiceDateProvider.zonedNowWithTime();
-        String dateRangeStart = hearingServiceDateProvider
-            .calculateDueDate(now, HEARING_START_WINDOW_INTERVAL_DEFAULT)
-            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-        String dateRangeEnd = hearingServiceDateProvider
-            .calculateDueDate(now, HEARING_WINDOW_END_INTERVAL_DEFAULT)
-            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-        return HearingWindowModel.builder()
-            .dateRangeStart(dateRangeStart)
-            .dateRangeEnd(dateRangeEnd)
-            .build();
+
+        if (bailState.equals(BAIL_STATE_DECISION_CONDITIONAL_BAIL)) {
+            return HearingWindowModel.builder()
+                .dateRangeStart(hearingServiceDateProvider
+                                    .calculateDueDate(now, HEARING_START_WINDOW_INTERVAL_CONDITIONAL_BAIL)
+                                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .build();
+        } else {
+            return HearingWindowModel.builder()
+                .dateRangeStart(hearingServiceDateProvider
+                                    .calculateDueDate(now, HEARING_START_WINDOW_INTERVAL_DEFAULT)
+                                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .dateRangeEnd(hearingServiceDateProvider
+                                  .calculateDueDate(now, HEARING_WINDOW_END_INTERVAL_DEFAULT)
+                                  .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .build();
+        }
+
     }
 
     public String getCaseSlaStartDate(BailCase bailCase) {

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/BailCaseDataToServiceHearingValuesMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/BailCaseDataToServiceHearingValuesMapperTest.java
@@ -1,5 +1,24 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.mappers.bail;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DISABILITY1;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DISABILITY_DETAILS;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DOCUMENTS_WITH_METADATA;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_PARTY_ID;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_COMPANY;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_EMAIL;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_INDIVIDUAL_PARTY_ID;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_NAME;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_ORGANISATION_PARTY_ID;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_PHONE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.VIDEO_HEARING1;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.DocumentTag.BAIL_SUBMISSION;
+
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -22,25 +41,6 @@ import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.Document;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingWindowModel;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DISABILITY1;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DISABILITY_DETAILS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DOCUMENTS_WITH_METADATA;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_PARTY_ID;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_COMPANY;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_EMAIL;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_INDIVIDUAL_PARTY_ID;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_NAME;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_ORGANISATION_PARTY_ID;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_PHONE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.VIDEO_HEARING1;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.DocumentTag.BAIL_SUBMISSION;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -106,7 +106,7 @@ class BailCaseDataToServiceHearingValuesMapperTest {
         when(hearingServiceDateProvider
                  .calculateDueDate(hearingServiceDateProvider.zonedNowWithTime(), 7))
             .thenReturn(expectedEndDate);
-        HearingWindowModel hearingWindowModel = mapper.getHearingWindowModel();
+        HearingWindowModel hearingWindowModel = mapper.getHearingWindowModel("applicationSubmitted");
 
         assertEquals(expectedStartDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
                      hearingWindowModel.getDateRangeStart());

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProviderTest.java
@@ -12,6 +12,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.IS_APPEAL_SUITABLE_TO_FLOAT;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.S94B_STATUS;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.CASE_NAME_HMCTS_INTERNAL;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.Facilities.IAC_TYPE_C_CONFERENCE_EQUIPMENT;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.ANONYMITY;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.AppealType.RP;
@@ -82,6 +83,7 @@ class ServiceHearingValuesProviderTest {
     private final String dateRangeEnd = "2023-08-15";
     private final String caseDeepLink = "/cases/case-details/1234567891234567#Overview";
     private final String listingComments = "Customer behaviour: unfriendly";
+    private final String bailState = "applicationSubmitted";
     private final HearingWindowModel hearingWindowModel = HearingWindowModel.builder()
         .dateRangeStart(dateStr)
         .dateRangeEnd(dateRangeEnd)
@@ -190,7 +192,7 @@ class ServiceHearingValuesProviderTest {
         when(bailCaseDataMapper.getHearingChannels(bailCase)).thenReturn(bailHearingChannels);
         when(bailCaseDataMapper.getExternalCaseReference(bailCase)).thenReturn(homeOfficeRef);
         when(bailCaseDataMapper.getCaseSlaStartDate(bailCase)).thenReturn(dateStr);
-        when(bailCaseDataMapper.getHearingWindowModel()).thenReturn(hearingWindowModel);
+        when(bailCaseDataMapper.getHearingWindowModel(bailState)).thenReturn(hearingWindowModel);
         when(bailCaseDataMapper.getListingComments(bailCase)).thenReturn(listingComments);
         when(bailCaseFlagsMapper.getPublicCaseName(bailCase, caseReference)).thenReturn(caseReference);
         when(bailCaseFlagsMapper.getHearingPriorityType(bailCase)).thenReturn(PriorityType.STANDARD);
@@ -208,6 +210,8 @@ class ServiceHearingValuesProviderTest {
             .thenReturn(partyDetails);
 
         when(bailCase.read(CASE_NAME_HMCTS_INTERNAL, String.class)).thenReturn(Optional.of(caseNameHmctsInternal));
+        when(bailCase.read(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, String.class))
+            .thenReturn(Optional.of(bailState));
 
         when(partyDetailsMapper.mapBailPartyDetails(bailCase, bailCaseFlagsMapper, bailCaseDataMapper))
             .thenReturn(partyDetails);


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8092](https://tools.hmcts.net/jira/browse/RIA-8092)


### Change description ###
- Scenario 8 required HearingWindow to have a startDate 28 working days in the future when the bail case state is `decisionConditionalBail`, instead of the standard 2 working days for startDate and 7 working days for endDate


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
