### PR TITLE
RIA-8386 Vulnerability set to true for unaccompanied minors

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/BailCaseFlagsToServiceHearingValuesMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/BailCaseFlagsToServiceHearingValuesMapper.java
@@ -3,12 +3,7 @@ package uk.gov.hmcts.reform.iahearingsapi.domain.mappers.bail;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPELLANT_LEVEL_FLAGS;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.CASE_FLAGS;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.FCS_LEVEL_FLAGS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.ANONYMITY;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.EVIDENCE_GIVEN_IN_PRIVATE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.LANGUAGE_INTERPRETER;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.URGENT_CASE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.VULNERABLE_USER;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -110,7 +105,7 @@ public class BailCaseFlagsToServiceHearingValuesMapper {
             bailCase.read(APPELLANT_LEVEL_FLAGS, BailStrategicCaseFlag.class)
                 .map(List::of).orElse(Collections.emptyList());
 
-        return hasOneOrMoreActiveFlagsOfType(appellantCaseFlags, List.of(VULNERABLE_USER));
+        return hasOneOrMoreActiveFlagsOfType(appellantCaseFlags, List.of(VULNERABLE_USER, UNACCOMPANIED_MINOR));
     }
 
     public String getVulnerableDetails(BailCase bailCase) {

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/BailCaseFlagsToServiceHearingValuesMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/bail/BailCaseFlagsToServiceHearingValuesMapper.java
@@ -3,7 +3,13 @@ package uk.gov.hmcts.reform.iahearingsapi.domain.mappers.bail;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.APPELLANT_LEVEL_FLAGS;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.CASE_FLAGS;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.FCS_LEVEL_FLAGS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.*;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.ANONYMITY;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.EVIDENCE_GIVEN_IN_PRIVATE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.LANGUAGE_INTERPRETER;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.UNACCOMPANIED_MINOR;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.URGENT_CASE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.StrategicCaseFlagType.VULNERABLE_USER;
 
 import java.util.ArrayList;
 import java.util.Collection;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-8386

### Change description ###

- Adding 'Unaccompanied minors' so that vulnerability flag would be set to true in hearing payload
- Unit test already mocked this so no changes were needed there

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
