### PR TITLE
RIA-8397 Made manualCanHearingRequired set to NO when deletion successful

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/DecideAnApplicationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/DecideAnApplicationHandler.java
@@ -5,6 +5,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_CANCEL_HEARINGS_REQUIRED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.DECIDE_AN_APPLICATION;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo.YES;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.AWAITING_LISTING;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.HEARING_REQUESTED;
@@ -69,6 +70,7 @@ public class DecideAnApplicationHandler  implements PreSubmitCallbackHandler<Asy
                             .deleteHearing(Long.valueOf(hearing.getHearingRequestId()), cancellationReason)
                             .getStatusCode();
                     });
+            asylumCase.write(MANUAL_CANCEL_HEARINGS_REQUIRED, NO);
         } catch (HmcException e) {
             asylumCase.write(MANUAL_CANCEL_HEARINGS_REQUIRED, YES);
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8397](https://tools.hmcts.net/jira/browse/RIA-8397)


### Change description ###
- Made the handler set `manualCanHearingRequired` to NO when deletion is successful


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
