### PR TITLE
RIA-8407 Default to empty string if localAuthorityPolicy null

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/CaseDataToServiceHearingValuesMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/CaseDataToServiceHearingValuesMapper.java
@@ -173,9 +173,9 @@ public class CaseDataToServiceHearingValuesMapper {
     public String getLegalRepOrganisationIdentifier(AsylumCase asylumCase) {
         Organisation organisation = asylumCase.read(LOCAL_AUTHORITY_POLICY, OrganisationPolicy.class)
             .map(OrganisationPolicy::getOrganisation)
-            .orElseThrow(() -> new RequiredFieldMissingException("localAuthorityPolicy is a required field"));
+            .orElse(null);
 
-        return defaultIfNull(organisation.getOrganisationID(), "");
+        return organisation == null ? "" : defaultIfNull(organisation.getOrganisationID(), "");
     }
 
     public List<UnavailabilityRangeModel> getUnavailabilityRanges(AsylumCase asylumCase) {

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/CaseDataToServiceHearingValuesMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/CaseDataToServiceHearingValuesMapperTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.ADDITIONAL_TRIBUNAL_RESPONSE;
@@ -488,12 +487,11 @@ class CaseDataToServiceHearingValuesMapperTest {
     }
 
     @Test
-    void getLegalRepOrganisationIdentifier_should_throw_exception_if_no_local_authority_policy() {
+    void getLegalRepOrganisationIdentifier_should_default_to_empty_string_if_no_local_authority() {
         when(asylumCase.read(LOCAL_AUTHORITY_POLICY, OrganisationPolicy.class))
             .thenReturn(Optional.empty());
 
-        assertThrows(RequiredFieldMissingException.class,
-                     () -> mapper.getLegalRepOrganisationIdentifier(asylumCase));
+        assertEquals("", mapper.getLegalRepOrganisationIdentifier(asylumCase));
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8407](https://tools.hmcts.net/jira/browse/RIA-8407)


### Change description ###
- Instead of throwing an exception when `localAuthorityPolicy` is missing, it'll just default to null string


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
