### PR TITLE
RIA-8432 RIA-8433 tweak legal rep party

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -39,6 +39,7 @@ public enum AsylumCaseFieldDefinition {
         "legalRepresentativeEmailAddress", new TypeReference<String>(){}),
     LEGAL_REP_MOBILE_PHONE_NUMBER(
         "legalRepMobilePhoneNumber", new TypeReference<String>(){}),
+    LEGAL_REP_COMPANY("legalRepCompany", new TypeReference<String>(){}),
     LEGAL_REP_COMPANY_NAME("legalRepCompanyName", new TypeReference<String>(){}),
     LOCAL_AUTHORITY_POLICY(
         "localAuthorityPolicy", new TypeReference<OrganisationPolicy>(){}),
@@ -269,7 +270,9 @@ public enum AsylumCaseFieldDefinition {
         "makeAnApplicationDecisionReason", new TypeReference<String>(){}
     ),
     CURRENT_ADJOURNMENT_DETAIL(
-        "currentAdjournmentDetail", new TypeReference<AdjournmentDetail>(){});
+        "currentAdjournmentDetail", new TypeReference<AdjournmentDetail>(){}),
+    CHANGE_ORGANISATION_REQUEST_FIELD(
+        "changeOrganisationRequestField", new TypeReference<ChangeOrganisationRequest>(){}),;
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/ChangeOrganisationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/ChangeOrganisationRequest.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.iahearingsapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChangeOrganisationRequest {
+
+    @JsonProperty("CaseRoleId")
+    private DynamicList caseRoleId;
+
+    @JsonProperty("RequestTimestamp")
+    private String requestTimestamp;
+
+    @JsonProperty("ApprovalStatus")
+    private String approvalStatus;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/CaseDataToServiceHearingValuesMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/CaseDataToServiceHearingValuesMapper.java
@@ -11,7 +11,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.IS_ADDITIONAL_ADJUSTMENTS_ALLOWED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.IS_MULTIMEDIA_ALLOWED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.IS_VULNERABILITIES_ALLOWED;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LEGAL_REP_COMPANY_NAME;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LEGAL_REP_COMPANY;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LEGAL_REP_INDIVIDUAL_PARTY_ID;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LEGAL_REP_ORGANISATION_PARTY_ID;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE;
@@ -177,9 +177,9 @@ public class CaseDataToServiceHearingValuesMapper {
             .orElseThrow(() -> new RequiredFieldMissingException("sponsorPartyId is a required field"));
     }
 
-    public String getLegalRepCompanyName(AsylumCase asylumCase) {
-        return asylumCase.read(LEGAL_REP_COMPANY_NAME, String.class)
-            .orElseThrow(() -> new RequiredFieldMissingException("legalRepCompanyName is a required field"));
+    public String getLegalRepCompany(AsylumCase asylumCase) {
+        return asylumCase.read(LEGAL_REP_COMPANY, String.class)
+            .orElseThrow(() -> new RequiredFieldMissingException("legalRepCompany is a required field"));
     }
 
     public String getLegalRepOrganisationIdentifier(AsylumCase asylumCase) {

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LegalRepOrgDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LegalRepOrgDetailsMapper.java
@@ -20,7 +20,7 @@ public class LegalRepOrgDetailsMapper {
             .organisationDetails(
                 OrganisationDetailsModel.builder()
                     .organisationType(PartyType.ORG.getPartyType())
-                    .name(caseDataMapper.getLegalRepCompanyName(asylumCase))
+                    .name(caseDataMapper.getLegalRepCompany(asylumCase))
                     .cftOrganisationID(caseDataMapper.getLegalRepOrganisationIdentifier(asylumCase))
                     .build())
             .build();

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/MapperUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/MapperUtils.java
@@ -4,6 +4,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_GIVEN_NAMES;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_IN_UK;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_NAME_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_ORGANISATION_REQUEST_FIELD;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HAS_SPONSOR;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.S94B_STATUS;
@@ -12,6 +13,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.JourneyType.REP;
 
 import java.util.Objects;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ChangeOrganisationRequest;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo;
 
 public class MapperUtils {
@@ -42,6 +44,11 @@ public class MapperUtils {
     public static boolean isRepJourney(AsylumCase asylumCase) {
         return asylumCase.read(JOURNEY_TYPE, String.class)
             .map(journeyType -> Objects.equals(REP.getValue(), journeyType)).orElse(true);
+    }
+
+    // ChangeOrganisationRequest is present when the case is in between representations
+    public static boolean isChangeOrganisationRequestPresent(AsylumCase asylumCase) {
+        return asylumCase.read(CHANGE_ORGANISATION_REQUEST_FIELD, ChangeOrganisationRequest.class).isPresent();
     }
 
     public static boolean isAppellantInUk(AsylumCase asylumCase) {

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/PartyDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/PartyDetailsMapper.java
@@ -54,7 +54,9 @@ public class PartyDetailsMapper {
         if (MapperUtils.hasSponsor(asylumCase)) {
             partyDetails.add(sponsorDetailsMapper.map(asylumCase, caseDataMapper));
         }
-        if (MapperUtils.isRepJourney(asylumCase)) {
+        if (MapperUtils.isRepJourney(asylumCase)
+            && !MapperUtils.isChangeOrganisationRequestPresent(asylumCase)) {
+
             partyDetails.add(legalRepDetailsMapper.map(asylumCase, caseDataMapper));
             partyDetails.add(legalRepOrgDetailsMapper.map(asylumCase, caseDataMapper));
         }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LegalRepOrgDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LegalRepOrgDetailsMapperTest.java
@@ -29,7 +29,7 @@ class LegalRepOrgDetailsMapperTest {
     void should_asylum_map_correctly() {
 
         when(caseDataMapper.getLegalRepOrgPartyId(asylumCase)).thenReturn("partyId");
-        when(caseDataMapper.getLegalRepCompanyName(asylumCase)).thenReturn("legaRepPartyName");
+        when(caseDataMapper.getLegalRepCompany(asylumCase)).thenReturn("legaRepPartyName");
         when(caseDataMapper.getLegalRepOrganisationIdentifier(asylumCase)).thenReturn("legalRepOrgId");
         PartyDetailsModel expected = PartyDetailsModel.builder()
             .partyID("partyId")

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/MapperUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/MapperUtilsTest.java
@@ -4,11 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_FAMILY_NAME;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_GIVEN_NAMES;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_IN_UK;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_NAME_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_ORGANISATION_REQUEST_FIELD;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HAS_SPONSOR;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.S94B_STATUS;
@@ -23,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ChangeOrganisationRequest;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo;
 
 @ExtendWith(MockitoExtension.class)
@@ -141,6 +144,24 @@ class MapperUtilsTest {
         when(asylumCase.read(HAS_SPONSOR, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
 
         assertFalse(MapperUtils.hasSponsor(asylumCase));
+    }
+
+    @Test
+    void isChangeOrganisationRequestPresent_should_return_true() {
+
+        when(asylumCase.read(CHANGE_ORGANISATION_REQUEST_FIELD, ChangeOrganisationRequest.class))
+            .thenReturn(Optional.of(mock(ChangeOrganisationRequest.class)));
+
+        assertTrue(MapperUtils.isChangeOrganisationRequestPresent(asylumCase));
+    }
+
+    @Test
+    void isChangeOrganisationRequestPresent_should_return_false() {
+
+        when(asylumCase.read(CHANGE_ORGANISATION_REQUEST_FIELD, ChangeOrganisationRequest.class))
+            .thenReturn(Optional.empty());
+
+        assertFalse(MapperUtils.isChangeOrganisationRequestPresent(asylumCase));
     }
 
 }


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-8432](https://tools.hmcts.net/jira/browse/RIA-8432)
[RIA-8433](https://tools.hmcts.net/jira/browse/RIA-8433)


### Change description ###
- Made `LegalRepOrgDetailsMapper` use `legalRepCompany` instead of `legalRepCompanyName`
- Made `PartyDetailsMapper`  generate LegalRepDetails and LegalRepOrgDetails (`party` entries in the hearing payload) when the journey isn't `AIP` && `changeOrganisationRequestField` isn't present (so representation isn't undergoing change)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
