### PR TITLE
RIA-8419 Trigger DecisionWithoutHearingListed if no partiesNotified present

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/DecisionWithoutHearingListed.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/DecisionWithoutHearingListed.java
@@ -55,7 +55,10 @@ public class DecisionWithoutHearingListed implements ServiceDataHandler<ServiceD
             .orElseThrow(() -> new IllegalStateException("HearingID can not be missing"));
         PartiesNotifiedResponses partiesNotifiedResponses = hearingService.getPartiesNotified(hearingId);
 
-        if (partiesNotifiedResponses != null && !partiesNotifiedResponses.getResponses().isEmpty()) {
+        boolean isFirstListingUpdate = partiesNotifiedResponses == null
+                                              || partiesNotifiedResponses.getResponses().isEmpty();
+
+        if (isFirstListingUpdate) {
             String caseId = serviceData.read(CASE_REF, String.class)
                 .orElseThrow(() -> new IllegalStateException("Case reference can not be null"));
 

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/DecisionWithoutHearingListedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/DecisionWithoutHearingListedTest.java
@@ -94,7 +94,7 @@ public class DecisionWithoutHearingListedTest {
         when(hearingService.getPartiesNotified(HEARING_REQ_ID)).thenReturn(
             PartiesNotifiedResponses.builder()
                 .hearingID(HEARING_REQ_ID)
-                .responses(List.of(partiesNotifiedResponse))
+                .responses(Collections.emptyList())
                 .build()
         );
         when(coreCaseDataService.startCaseEvent(
@@ -131,7 +131,7 @@ public class DecisionWithoutHearingListedTest {
         when(hearingService.getPartiesNotified(HEARING_REQ_ID)).thenReturn(
             PartiesNotifiedResponses.builder()
                 .hearingID(HEARING_REQ_ID)
-                .responses(Collections.emptyList())
+                .responses(List.of(partiesNotifiedResponse))
                 .build()
         );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8419](https://tools.hmcts.net/jira/browse/RIA-8419)


### Change description ###
- Invert the condition to trigger `DecisionWithoutHearingListed` so it's triggered when partiesNotified returns empty (meaning this is the first LISTED update received, otherwise this would be a following update, which should be ignored)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
