### PR TITLE
RIA-8552 -  Fix to prevent handlers being triggered from the outcome of another handler

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/HmcUpdateDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/hmc/HmcUpdateDispatcher.java
@@ -35,15 +35,8 @@ public class HmcUpdateDispatcher<T extends ServiceData> {
         List<ServiceDataHandler<T>> handlers,
         DispatchPriority dispatchPriority
     ) {
-        for (ServiceDataHandler<T> handler : handlers) {
-
-            if (handler.getDispatchPriority() == dispatchPriority) {
-
-                if (handler.canHandle(update)) {
-
-                    handler.handle(update);
-                }
-            }
-        }
+        handlers.stream()
+            .filter(h -> h.getDispatchPriority() == dispatchPriority && h.canHandle(update))
+            .forEach(h -> h.handle(update));
     }
 }


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-8552


### Change description ###
 Fix to prevent handlers being triggered from the outcome of another handler


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
