### PR TITLE
RIA-8599 PF0015 in list of flags for Reasonable Adjustments in party details (Bails)

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LanguageAndAdjustmentsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/LanguageAndAdjustmentsMapperTest.java
@@ -142,7 +142,7 @@ public class LanguageAndAdjustmentsMapperTest {
         mapper.processBailPartyCaseFlags(bailCase, partyDetailsModel);
 
         verify(individualDetailsModel, times(1)).setInterpreterLanguage("bfi");
-        verify(reasonableAdjustments, times(1)).addAll(List.of("RA0042", "RA0018"));
+        verify(reasonableAdjustments, times(1)).addAll(List.of("RA0042", "PF0015", "RA0018"));
         verify(individualDetailsModel, times(1))
             .setOtherReasonableAdjustmentDetails("Interpreter: German; "
                                                      + "Support filling in forms: comment of r.a. flag;");
@@ -272,7 +272,13 @@ public class LanguageAndAdjustmentsMapperTest {
         mapper.processBailPartyCaseFlags(bailCase, partyDetailsModel);
 
         verify(individualDetailsModel, times(1)).setInterpreterLanguage("ita");
-        verify(reasonableAdjustments, times(1)).addAll(List.of("SM0004", "RA0018"));
+        verify(reasonableAdjustments, times(1)).addAll(List.of(
+            "SM0004",
+            "PF0015",
+            "PF0015",
+            "PF0015",
+            "RA0018")
+        );
         verify(individualDetailsModel, times(1))
             .setOtherReasonableAdjustmentDetails("Interpreter: Portuguese; "
                                                      + "Interpreter: Sardinian; "


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8599](https://tools.hmcts.net/jira/browse/RIA-8599)


### Change description ###
- `PF0015` flag to be included in Reasonable Adjustments field of partyDetails for Bails along SM and RA flags


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
