### PR TITLE
RIA-8612 change hearing location to ref data in record adjournment details event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -260,8 +260,8 @@ public enum AsylumCaseFieldDefinition {
         "nextHearingFormat", new TypeReference<DynamicList>(){}),
     NEXT_HEARING_DURATION(
         "nextHearingDuration", new TypeReference<String>(){}),
-    NEXT_HEARING_LOCATION(
-        "nextHearingLocation", new TypeReference<String>(){}),
+    NEXT_HEARING_VENUE(
+        "nextHearingVenue", new TypeReference<DynamicList>(){}),
 
     IS_APPEAL_SUITABLE_TO_FLOAT(
         "isAppealSuitableToFloat", new TypeReference<YesOrNo>() {}),

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadService.java
@@ -4,9 +4,8 @@ import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HEARING_LOCATION;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.NEXT_HEARING_DURATION;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.NEXT_HEARING_LOCATION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.NEXT_HEARING_VENUE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.Facilities.IAC_TYPE_C_CONFERENCE_EQUIPMENT;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.getEpimsIdByValue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -122,11 +121,8 @@ public class UpdateHearingPayloadService extends CreateHearingPayloadService {
         if (event != null) {
             switch (event) {
                 case RECORD_ADJOURNMENT_DETAILS:
-                    locationCodes = Optional.of(
-                        getEpimsIdByValue(
-                            asylumCase.read(NEXT_HEARING_LOCATION, String.class)
-                                .orElseThrow(() -> new IllegalStateException(
-                                 NEXT_HEARING_LOCATION + "  is not present"))));
+                    locationCodes = asylumCase.read(NEXT_HEARING_VENUE, DynamicList.class)
+                        .map(hearingLocation -> hearingLocation.getValue().getCode());
                     break;
 
                 case UPDATE_HEARING_REQUEST:

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HEARING_LOCATION;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.NEXT_HEARING_LOCATION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.NEXT_HEARING_VENUE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.S94B_STATUS;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.Facilities.IAC_TYPE_C_CONFERENCE_EQUIPMENT;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.DECISION_WITHOUT_HEARING;
@@ -390,8 +390,8 @@ class UpdateHearingPayloadServiceTest {
             .thenReturn(List.of(hearingChannel));
 
 
-        when(asylumCase.read(NEXT_HEARING_LOCATION, String.class))
-            .thenReturn(Optional.of(LEEDS_MAGS.getValue()));
+        when(asylumCase.read(NEXT_HEARING_VENUE, DynamicList.class))
+            .thenReturn(Optional.of(new DynamicList("569737")));
         Integer duration = 240;
         when(updateHearingPayloadService.getHearingDuration(asylumCase, Event.RECORD_ADJOURNMENT_DETAILS))
             .thenReturn(duration);
@@ -507,8 +507,8 @@ class UpdateHearingPayloadServiceTest {
     @Test
     void should_return_next_hearing_value_when_the_event_is_record_adjournment_details() {
 
-        when(asylumCase.read(NEXT_HEARING_LOCATION, String.class)).thenReturn(
-            Optional.of(HearingCentre.NEWPORT.getValue()));
+        when(asylumCase.read(NEXT_HEARING_VENUE, DynamicList.class)).thenReturn(
+            Optional.of(new DynamicList("227101")));
         when(updateHearingPayloadService.getHearingDuration(asylumCase, Event.RECORD_ADJOURNMENT_DETAILS))
             .thenReturn(60);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-8612


### Change description ###
- rename from nextHearingLocation to the nextHearingVenue
- retrieve the value from reference data for nextHearingVenue instead of using fixedList
- update unit test


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
