### PR TITLE
RIA-8619 Change logic around the triggers for editCaseListing

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/EditListCaseHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/servicedatahandlers/EditListCaseHandlerTest.java
@@ -166,24 +166,6 @@ class EditListCaseHandlerTest {
     }
 
     @Test
-    void should_not_trigger_events_when_hearing_time_changes() {
-        initializeServiceData();
-        initializeAsylumCaseData();
-        when(serviceData.read(ServiceDataFieldDefinition.HEARING_VENUE_ID, String.class))
-            .thenReturn(Optional.of(HearingCentre.GLASGOW.getEpimsId()));
-        when(serviceData.read(ServiceDataFieldDefinition.NEXT_HEARING_DATE, LocalDateTime.class))
-            .thenReturn(Optional.of(NEXT_HEARING_DATE.plusHours(1)));
-
-        editListCaseHandler.handle(serviceData);
-
-        verify(asylumCase, never()).write(SHOULD_TRIGGER_REVIEW_INTERPRETER_TASK, YES);
-
-        verify(coreCaseDataService, never()).triggerSubmitEvent(
-            EDIT_CASE_LISTING, CASE_REFERENCE, startEventResponse, asylumCase);
-    }
-
-
-    @Test
     void should_trigger_events_when_venue_changes() {
         initializeServiceData();
         initializeAsylumCaseData();
@@ -284,8 +266,7 @@ class EditListCaseHandlerTest {
             Arguments.of(List.of(HearingChannel.INTER), HearingCentre.BIRMINGHAM.getEpimsId(), true),
             Arguments.of(List.of(HearingChannel.INTER), HearingCentre.GLASGOW.getEpimsId(), true),
             Arguments.of(List.of(HearingChannel.TEL), HearingCentre.GLASGOW.getEpimsId(), true),
-            Arguments.of(List.of(HearingChannel.TEL), HearingCentre.BIRMINGHAM.getEpimsId(), true),
-            Arguments.of(List.of(HearingChannel.INTER), HearingCentre.NEWPORT.getEpimsId(), false)
+            Arguments.of(List.of(HearingChannel.TEL), HearingCentre.BIRMINGHAM.getEpimsId(), true)
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8619](https://tools.hmcts.net/jira/browse/RIA-8619)


### Change description ###
- Made editCaseListing trigger if there's a change in the date and time of the hearing (the time being calculated based on whether the hearing is physically in Glasgow or elsewhere)
- Reverted the hearingCentre check between old and new value back to what it was (which compares the two location values instead of location value VS. physical venue): so `remoteHearing` == `remoteHearing`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
