### PR TITLE
RIA-8608 Populate LoV of hearing channel dynamic list

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestHandler.java
@@ -90,9 +90,16 @@ public class UpdateHearingRequestHandler implements PreSubmitCallbackHandler<Asy
     }
 
     private void setHearingChannelDetails(AsylumCase asylumCase, HearingDetails hearingDetails) {
+        List<Value> allChannelsOptions = Arrays.stream(HearingChannel.values())
+            .map(hearingChannel -> new Value(hearingChannel.name(), hearingChannel.getLabel()))
+            .toList();
+
         asylumCase.read(HEARING_CHANNEL, DynamicList.class).ifPresentOrElse(hearingChannel -> {
             asylumCase.write(CHANGE_HEARING_TYPE, hearingChannel.getValue().getLabel());
-            asylumCase.write(REQUEST_HEARING_CHANNEL, hearingChannel);
+            asylumCase.write(REQUEST_HEARING_CHANNEL, new DynamicList(
+                hearingChannel.getValue(),
+                allChannelsOptions
+            ));
         }, () -> {
             List<String> hearingChannels = hearingDetails.getHearingChannels();
             if (!(hearingChannels == null || hearingChannels.isEmpty())) {
@@ -105,9 +112,7 @@ public class UpdateHearingRequestHandler implements PreSubmitCallbackHandler<Asy
                         hearingDetails.getHearingChannels().get(0),
                         hearingDetails.getHearingChannelDescription()
                     ),
-                    Arrays.stream(HearingChannel.values())
-                        .map(hearingChannel -> new Value(hearingChannel.name(), hearingChannel.getLabel()))
-                        .toList()
+                    allChannelsOptions
                 ));
             }
         });

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestHandlerTest.java
@@ -34,6 +34,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.UPDATE
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -54,6 +55,7 @@ import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingGetResponse;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingLocationModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingWindowModel;
@@ -148,7 +150,9 @@ class UpdateHearingsRequestHandlerTest {
         verify(asylumCase).write(eq(CHANGE_HEARING_TYPE), stringArgumentCaptor.capture());
         verify(asylumCase).write(eq(REQUEST_HEARING_CHANNEL), dynamicListArgumentCaptor.capture());
         assertEquals(hearingChannel.getValue().getLabel(), stringArgumentCaptor.getValue());
-        assertEquals(hearingChannel, dynamicListArgumentCaptor.getValue());
+        assertEquals(hearingChannel.getValue(), dynamicListArgumentCaptor.getValue().getValue());
+        assertTrue(dynamicListArgumentCaptor.getValue().getListItems().stream().map(Value::getLabel).toList()
+                       .containsAll(Arrays.stream(HearingChannel.values()).map(HearingChannel::getLabel).toList()));
     }
 
     @Test
@@ -162,7 +166,9 @@ class UpdateHearingsRequestHandlerTest {
         verify(asylumCase).write(eq(CHANGE_HEARING_TYPE), stringArgumentCaptor.capture());
         verify(asylumCase).write(eq(REQUEST_HEARING_CHANNEL), dynamicListArgumentCaptor.capture());
         assertEquals(hearingChannel.getValue().getLabel(), stringArgumentCaptor.getValue());
-        assertEquals(hearingChannel, dynamicListArgumentCaptor.getValue());
+        assertEquals(hearingChannel.getValue(), dynamicListArgumentCaptor.getValue().getValue());
+        assertTrue(dynamicListArgumentCaptor.getValue().getListItems().stream().map(Value::getLabel).toList()
+                       .containsAll(Arrays.stream(HearingChannel.values()).map(HearingChannel::getLabel).toList()));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8608](https://tools.hmcts.net/jira/browse/RIA-8608)


### Change description ###
- After listing, when triggering `updateHearingRequest`, the hearing channel radio-button list would only display 1 option (the previously selected hearing channel), while it should display all options with the previously selected option prepopulated.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
