### PR TITLE
RIA-8601 Populate LoV of locations when listCaseHearingCentre is remote

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestHandler.java
@@ -128,8 +128,8 @@ public class UpdateHearingRequestHandler implements PreSubmitCallbackHandler<Asy
             if (!(listCaseHearingCentre == REMOTE_HEARING || listCaseHearingCentre == DECISION_WITHOUT_HEARING)) {
                 Value hearingVenueValue = getHearingVenueValue(hearingLocation, listCaseHearingCentre.getEpimsId());
                 hearingLocation.setValue(hearingVenueValue);
-                asylumCase.write(HEARING_LOCATION, hearingLocation);
             }
+            asylumCase.write(HEARING_LOCATION, hearingLocation);
         } else {
             List<HearingLocationModel> hearingLocations = hearingDetails.getHearingLocations();
             if (hearingLocations == null || hearingLocations.isEmpty()) {

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestHandlerTest.java
@@ -188,7 +188,7 @@ class UpdateHearingsRequestHandlerTest {
         when(asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class)).thenReturn(Optional.of(REMOTE_HEARING));
         updateHearingsRequestHandler.handle(MID_EVENT, callback);
 
-        verify(asylumCase, never()).write(eq(HEARING_LOCATION), any());
+        verify(asylumCase, times(1)).write(eq(HEARING_LOCATION), any());
         verify(asylumCase).write(eq(CHANGE_HEARING_VENUE), stringArgumentCaptor.capture());
         assertEquals(REMOTE_HEARING.getValue(), stringArgumentCaptor.getValue());
     }
@@ -199,8 +199,9 @@ class UpdateHearingsRequestHandlerTest {
             .thenReturn(Optional.of(DECISION_WITHOUT_HEARING));
         updateHearingsRequestHandler.handle(MID_EVENT, callback);
 
-        verify(asylumCase, never()).write(eq(HEARING_LOCATION), any());
         verify(asylumCase).write(eq(CHANGE_HEARING_VENUE), stringArgumentCaptor.capture());
+        verify(asylumCase, times(1)).write(eq(HEARING_LOCATION), any());
+
         assertEquals(DECISION_WITHOUT_HEARING.getValue(), stringArgumentCaptor.getValue());
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8601](https://tools.hmcts.net/jira/browse/RIA-8601)


### Change description ###
- `hearingLocation` list was not getting populated when `listCaseHearingCentre` has an empty epimmsId (remoteHearing or decisionWithoutHearing), now it does (with no preselection)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
