### PR TITLE
RIA-8632 Overwrite newly selected values onto originally requested values

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestHandler.java
@@ -199,7 +199,8 @@ public class UpdateHearingRequestHandler implements PreSubmitCallbackHandler<Asy
         return true;
     }
 
-    private boolean setHearingDateDetailsFromRequestedHearing(AsylumCase asylumCase, HearingWindowModel hearingWindow) {
+    public static boolean setHearingDateDetailsFromRequestedHearing(AsylumCase asylumCase,
+                                                                    HearingWindowModel hearingWindow) {
         boolean hearingDateSet = false;
         final StringBuilder dateRangeBuilder = new StringBuilder("Choose a date range");
 

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestSubmit.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestSubmit.java
@@ -1,42 +1,59 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.handlers.presubmit;
 
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARINGS;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_RANGE_EARLIEST;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_RANGE_LATEST;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_TYPE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DURATION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DURATION_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_LOCATION_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_TYPE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_TYPE_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_UPDATE_REASON;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_VENUE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CHANNEL;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HEARING_LOCATION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_LENGTH;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_UPDATE_HEARING_REQUIRED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_CHANNEL;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_LENGTH;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.getValueByEpimsId;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.ListAssistCaseStatus.AWAITING_LISTING;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.ListAssistCaseStatus.CASE_CREATED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.handlers.presubmit.UpdateHearingRequestHandler.setHearingDateDetailsFromRequestedHearing;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iahearingsapi.domain.RequiredFieldMissingException;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.DynamicList;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingGetResponse;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingWindowModel;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.ListAssistCaseStatus;
 import uk.gov.hmcts.reform.iahearingsapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iahearingsapi.domain.service.HearingService;
 import uk.gov.hmcts.reform.iahearingsapi.domain.service.UpdateHearingPayloadService;
 import uk.gov.hmcts.reform.iahearingsapi.domain.utils.HearingsUtils;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.exception.HmcException;
 
-import java.util.Objects;
-import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARINGS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_RANGE_EARLIEST;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_RANGE_LATEST;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_TYPE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_YES_NO;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DURATION_YES_NO;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_LOCATION_YES_NO;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_TYPE_YES_NO;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_UPDATE_REASON;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_UPDATE_HEARING_REQUIRED;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo.YES;
-
 
 @Component
 @Slf4j
 public class UpdateHearingRequestSubmit implements PreSubmitCallbackHandler<AsylumCase> {
 
+    private static final String YES = "Yes";
     HearingService hearingService;
 
     UpdateHearingPayloadService updateHearingPayloadService;
@@ -65,18 +82,26 @@ public class UpdateHearingRequestSubmit implements PreSubmitCallbackHandler<Asyl
     public PreSubmitCallbackResponse<AsylumCase> handle(
         PreSubmitCallbackStage callbackStage,
         Callback<AsylumCase> callback) {
+
         if (!canHandle(callbackStage, callback)) {
             throw new IllegalStateException("Cannot handle callback");
         }
+
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
         Optional<DynamicList> selectedHearing = asylumCase.read(CHANGE_HEARINGS);
+
         selectedHearing.ifPresent(hearing -> {
+
             String hearingId = selectedHearing.get().getValue().getCode();
+
             boolean firstAvailableDate = false;
+
             String hearingDateChangeType = asylumCase.read(
                 CHANGE_HEARING_DATE_TYPE,
                 String.class
             ).orElse("");
+
             if (hearingDateChangeType.equals("FirstAvailableDate")) {
                 firstAvailableDate = true;
             }
@@ -94,6 +119,12 @@ public class UpdateHearingRequestSubmit implements PreSubmitCallbackHandler<Asyl
                     hearingId
                 );
 
+                HearingGetResponse updatedHearing = hearingService.getHearing(hearingId);
+
+                if (isHearingYetToBeListed(updatedHearing)) {
+                    rewriteRequestedFields(asylumCase);
+                }
+
                 clearFields(asylumCase);
 
             } catch (HmcException e) {
@@ -103,6 +134,81 @@ public class UpdateHearingRequestSubmit implements PreSubmitCallbackHandler<Asyl
 
 
         return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private void rewriteRequestedFields(AsylumCase asylumCase) {
+        if (isHearingTypeUpdated(asylumCase)) {
+            rewriteHearingChannel(asylumCase);
+        }
+        if (isLocationUpdated(asylumCase)) {
+            rewriteLocation(asylumCase);
+        }
+        if (isDurationUpdated(asylumCase)) {
+            rewriteDuration(asylumCase);
+        }
+        if (isDateTimeUpdated(asylumCase)) {
+            rewriteDateTime(asylumCase);
+        }
+    }
+
+    private void rewriteHearingChannel(AsylumCase asylumCase) {
+        asylumCase.read(REQUEST_HEARING_CHANNEL, DynamicList.class)
+            .ifPresentOrElse(hearingChannel -> {
+                asylumCase.write(CHANGE_HEARING_TYPE, hearingChannel.getValue().getLabel());
+                asylumCase.write(HEARING_CHANNEL, hearingChannel);
+                },
+                             throwRequiredFieldMissingError("Request Hearing Channel missing")
+            );
+    }
+
+    private void rewriteLocation(AsylumCase asylumCase) {
+        asylumCase.read(HEARING_LOCATION, DynamicList.class)
+            .map(dynamicList -> getValueByEpimsId(dynamicList.getValue().getCode()))
+            .ifPresentOrElse(
+                hearingVenueCodeName -> asylumCase.write(CHANGE_HEARING_VENUE, hearingVenueCodeName),
+                throwRequiredFieldMissingError("Hearing Location missing or unrecognized epims id"));
+    }
+
+    private void rewriteDuration(AsylumCase asylumCase) {
+        asylumCase.read(REQUEST_HEARING_LENGTH, String.class)
+                .ifPresentOrElse(duration -> {
+                    asylumCase.write(CHANGE_HEARING_DURATION, duration);
+                    asylumCase.write(LIST_CASE_HEARING_LENGTH, duration);
+                },
+                                 throwRequiredFieldMissingError("Request Hearing Length missing"));
+    }
+
+    private void rewriteDateTime(AsylumCase asylumCase) {
+        HearingWindowModel updatedHearingWindow = updateHearingWindow(asylumCase);
+        if (updatedHearingWindow != null) {
+            setHearingDateDetailsFromRequestedHearing(asylumCase, updatedHearingWindow);
+        } else {
+            asylumCase.write(CHANGE_HEARING_DATE, "First available date");
+        }
+    }
+
+    private boolean isLocationUpdated(AsylumCase asylumCase) {
+        return asylumCase.read(CHANGE_HEARING_LOCATION_YES_NO, String.class)
+            .map(this::isYes).orElse(false);
+    }
+
+    private boolean isDurationUpdated(AsylumCase asylumCase) {
+        return asylumCase.read(CHANGE_HEARING_DURATION_YES_NO, String.class)
+            .map(this::isYes).orElse(false);
+    }
+
+    private boolean isDateTimeUpdated(AsylumCase asylumCase) {
+        return asylumCase.read(CHANGE_HEARING_DATE_YES_NO, String.class)
+            .map(this::isYes).orElse(false);
+    }
+
+    private boolean isHearingTypeUpdated(AsylumCase asylumCase) {
+        return asylumCase.read(CHANGE_HEARING_TYPE_YES_NO, String.class)
+            .map(this::isYes).orElse(false);
+    }
+
+    private boolean isYes(String yesOrNo) {
+        return StringUtils.equalsIgnoreCase(yesOrNo, "Yes");
     }
 
     private String getReason(AsylumCase asylumCase) {
@@ -167,5 +273,16 @@ public class UpdateHearingRequestSubmit implements PreSubmitCallbackHandler<Asyl
         asylumCase.clear(CHANGE_HEARING_DATE_TYPE);
         asylumCase.clear(CHANGE_HEARING_DATE_RANGE_EARLIEST);
         asylumCase.clear(CHANGE_HEARING_DATE_RANGE_LATEST);
+    }
+
+    private boolean isHearingYetToBeListed(HearingGetResponse hearing) {
+        ListAssistCaseStatus laCaseStatus = hearing.getHearingResponse().getLaCaseStatus();
+        return laCaseStatus == null || Set.of(CASE_CREATED, AWAITING_LISTING).contains(laCaseStatus);
+    }
+
+    private Runnable throwRequiredFieldMissingError(String message) {
+        return () -> {
+            throw new RequiredFieldMissingException("Hearing Location missing or unrecognized epims id");
+        };
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestSubmitTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestSubmitTest.java
@@ -1,5 +1,47 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.handlers.presubmit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARINGS;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_RANGE_EARLIEST;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_RANGE_LATEST;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_TYPE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DURATION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DURATION_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_LOCATION_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_TYPE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_TYPE_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_UPDATE_REASON;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_VENUE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CHANNEL;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HEARING_LOCATION;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_LENGTH;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_UPDATE_HEARING_REQUIRED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_CHANNEL;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_LENGTH;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.NEWCASTLE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUEST;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo.YES;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel.INTER;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel.TEL;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingChannel.values;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.ListAssistCaseStatus.CASE_CREATED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.ListAssistCaseStatus.LISTED;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,41 +57,13 @@ import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingGetResponse;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingResponse;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HearingWindowModel;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.response.UpdateHearingRequest;
 import uk.gov.hmcts.reform.iahearingsapi.domain.service.HearingService;
 import uk.gov.hmcts.reform.iahearingsapi.domain.service.UpdateHearingPayloadService;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.hmc.HearingDetails;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.exception.HmcException;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARINGS;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_RANGE_EARLIEST;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_RANGE_LATEST;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_TYPE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_YES_NO;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DURATION_YES_NO;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_LOCATION_YES_NO;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_TYPE_YES_NO;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_UPDATE_REASON;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HEARING_LOCATION;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_UPDATE_HEARING_REQUIRED;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_CHANNEL;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_LENGTH;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUEST;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo.YES;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -67,7 +81,11 @@ class UpdateHearingsRequestSubmitTest {
     @Mock
     HearingGetResponse hearingGetResponse;
     @Mock
+    HearingGetResponse updatedHearing;
+    @Mock
     UpdateHearingRequest updateHearingRequest;
+    @Mock
+    HearingResponse updatedHearingResponse;
     HearingDetails hearingDetails = new HearingDetails();
     private final String updateHearingsCode = "code 1";
     UpdateHearingRequestSubmit updateHearingRequestSubmit;
@@ -76,6 +94,12 @@ class UpdateHearingsRequestSubmitTest {
         ReasonCodes.OTHER.name(),
         ReasonCodes.OTHER.toString()
     ), null);
+
+    private final DynamicList channel = new DynamicList(
+        new Value("", ""),
+        Arrays.stream(values())
+            .map(hearingChannel -> new Value(hearingChannel.name(), hearingChannel.getLabel()))
+            .toList());
 
     private AsylumCase asylumCase;
 
@@ -88,7 +112,9 @@ class UpdateHearingsRequestSubmitTest {
         when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
         when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUEST);
         when(hearingService.getHearing(updateHearingsCode)).thenReturn(hearingGetResponse);
-        when(hearingService.updateHearing(any(UpdateHearingRequest.class), any())).thenReturn(new HearingGetResponse());
+        when(hearingService.getHearing(anyString())).thenReturn(updatedHearing);
+        when(updatedHearing.getHearingResponse()).thenReturn(updatedHearingResponse);
+        when(updatedHearingResponse.getLaCaseStatus()).thenReturn(CASE_CREATED);
         when(updateHearingRequest.getHearingDetails()).thenReturn(hearingDetails);
         when(updateHearingPayloadService.createUpdateHearingPayload(
             any(),
@@ -106,8 +132,11 @@ class UpdateHearingsRequestSubmitTest {
     @Test
     void should_send_an_update_of_the_hearing_channels() {
 
-        asylumCase.write(REQUEST_HEARING_CHANNEL, "TEL");
+        channel.setValue(new Value(TEL.name(), TEL.getLabel()));
+
+        asylumCase.write(REQUEST_HEARING_CHANNEL, channel);
         asylumCase.write(CHANGE_HEARING_UPDATE_REASON, reasonCode);
+        asylumCase.write(CHANGE_HEARING_TYPE_YES_NO, YES);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse = updateHearingRequestSubmit.handle(
             ABOUT_TO_SUBMIT,
@@ -124,6 +153,9 @@ class UpdateHearingsRequestSubmitTest {
             null,
             UPDATE_HEARING_REQUEST
         );
+
+        assertEquals(TEL.getLabel(), asylumCase.read(CHANGE_HEARING_TYPE, String.class).orElse(""));
+        assertEquals(channel, asylumCase.read(HEARING_CHANNEL, DynamicList.class).orElse(null));
 
         verifyFieldsAreCleared();
     }
@@ -134,6 +166,7 @@ class UpdateHearingsRequestSubmitTest {
             new Value("366796", "Newcastle"),
             List.of(new Value("366796", "Newcastle"))));
         asylumCase.write(CHANGE_HEARING_UPDATE_REASON, reasonCode);
+        asylumCase.write(CHANGE_HEARING_LOCATION_YES_NO, YES);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse = updateHearingRequestSubmit.handle(
             ABOUT_TO_SUBMIT,
@@ -151,11 +184,14 @@ class UpdateHearingsRequestSubmitTest {
             UPDATE_HEARING_REQUEST
         );
 
+        assertEquals(NEWCASTLE.getValue(), asylumCase.read(CHANGE_HEARING_VENUE, String.class).orElse(""));
+
         verifyFieldsAreCleared();
     }
 
     @Test
     void should_send_an_update_of_the_hearing_window_date_to_be_fixed() {
+        asylumCase.write(CHANGE_HEARING_DATE_YES_NO, YES);
         asylumCase.write(CHANGE_HEARING_DATE_TYPE, "DateToBeFixed");
         asylumCase.write(REQUEST_HEARING_DATE, "2023-12-02T00:00:00.000");
         asylumCase.write(CHANGE_HEARING_UPDATE_REASON, reasonCode);
@@ -179,11 +215,16 @@ class UpdateHearingsRequestSubmitTest {
             newHearingWindow,
             UPDATE_HEARING_REQUEST
         );
+
+        assertEquals("Date to be fixed: 02 December 2023",
+                     asylumCase.read(CHANGE_HEARING_DATE, String.class).orElse(""));
+
         verifyFieldsAreCleared();
     }
 
     @Test
     void should_send_an_update_of_the_hearing_window_choose_a_date_range() {
+        asylumCase.write(CHANGE_HEARING_DATE_YES_NO, YES);
         asylumCase.write(CHANGE_HEARING_DATE_TYPE, "ChooseADateRange");
         asylumCase.write(CHANGE_HEARING_DATE_RANGE_EARLIEST, "2023-12-02");
         asylumCase.write(CHANGE_HEARING_DATE_RANGE_LATEST, "2023-12-26");
@@ -208,11 +249,16 @@ class UpdateHearingsRequestSubmitTest {
             newHearingWindow,
             UPDATE_HEARING_REQUEST
         );
+
+        assertEquals("Choose a date range: Earliest 02 December 2023: Latest 26 December 2023",
+                     asylumCase.read(CHANGE_HEARING_DATE, String.class).orElse(""));
+
         verifyFieldsAreCleared();
     }
 
     @Test
     void should_send_an_update_of_the_hearing_window_first_available_date() {
+        asylumCase.write(CHANGE_HEARING_DATE_YES_NO, YES);
         asylumCase.write(CHANGE_HEARING_DATE_TYPE, "FirstAvailableDate");
         asylumCase.write(CHANGE_HEARING_UPDATE_REASON, reasonCode);
 
@@ -231,6 +277,9 @@ class UpdateHearingsRequestSubmitTest {
             null,
             UPDATE_HEARING_REQUEST
         );
+
+        assertEquals("First available date", asylumCase.read(CHANGE_HEARING_DATE, String.class).orElse(""));
+
         verifyFieldsAreCleared();
     }
 
@@ -270,6 +319,7 @@ class UpdateHearingsRequestSubmitTest {
 
     @Test
     void should_send_an_update_of_the_hearing_duration() {
+        asylumCase.write(CHANGE_HEARING_DURATION_YES_NO, YES);
         asylumCase.write(REQUEST_HEARING_LENGTH, "240");
         asylumCase.write(CHANGE_HEARING_UPDATE_REASON, reasonCode);
 
@@ -287,6 +337,10 @@ class UpdateHearingsRequestSubmitTest {
             null,
             UPDATE_HEARING_REQUEST
         );
+
+        assertEquals("240", asylumCase.read(CHANGE_HEARING_DURATION, String.class).orElse(""));
+        assertEquals("240", asylumCase.read(LIST_CASE_HEARING_LENGTH, String.class).orElse(""));
+
         verifyFieldsAreCleared();
     }
 
@@ -312,6 +366,40 @@ class UpdateHearingsRequestSubmitTest {
         );
 
         assertThat(asylumCase.read(MANUAL_UPDATE_HEARING_REQUIRED), samePropertyValuesAs(Optional.of(YES)));
+    }
+
+    @Test
+    void should_not_rewrite_fields_if_hearing_had_been_listed_before() {
+
+        when(updatedHearingResponse.getLaCaseStatus()).thenReturn(LISTED);
+
+        channel.setValue(new Value(TEL.name(), TEL.getLabel()));
+
+        asylumCase.write(CHANGE_HEARING_TYPE, INTER.getLabel());
+        asylumCase.write(REQUEST_HEARING_CHANNEL, channel);
+        asylumCase.write(CHANGE_HEARING_UPDATE_REASON, reasonCode);
+        asylumCase.write(CHANGE_HEARING_TYPE_YES_NO, YES);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse = updateHearingRequestSubmit.handle(
+            ABOUT_TO_SUBMIT,
+            callback
+        );
+        assertEquals(asylumCase, callbackResponse.getData());
+        verify(hearingService, times(1)).updateHearing(any(), any());
+
+        verify(updateHearingPayloadService, times(1)).createUpdateHearingPayload(
+            asylumCase,
+            updateHearingsCode,
+            reasonCode.getValue().getCode(),
+            false,
+            null,
+            UPDATE_HEARING_REQUEST
+        );
+
+        // Still INTER, not changed to TEL
+        assertEquals(INTER.getLabel(), asylumCase.read(CHANGE_HEARING_TYPE, String.class).orElse(""));
+
+        verifyFieldsAreCleared();
     }
 
     private void verifyFieldsAreCleared() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8634](https://tools.hmcts.net/jira/browse/RIA-8634)


### Change description ###
- Made actually requested values be overwritten by newly requested values in `updateHearingRequest`:
  - `requestHearingChannel` → `changeHearingType` + `hearingChannel`
  - `hearingLocation` → `changeHearingVenue`
  - `requestHearingLength` → `changeHearingDuration` + `listCaseHearingLength`
  - `requestHearingDate` → `changeHearingDate`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
