### PR TITLE
RIA-8659 Read pageId for existing midEvent logic

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/PreSubmitCallbackDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/infrastructure/PreSubmitCallbackDispatcher.java
@@ -1,5 +1,10 @@
 package uk.gov.hmcts.reform.iahearingsapi.infrastructure;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.CaseData;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.Callback;
@@ -8,12 +13,6 @@ import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitC
 import uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iahearingsapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iahearingsapi.infrastructure.security.CcdEventAuthorizor;
-
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static java.util.Objects.requireNonNull;
 
 public class PreSubmitCallbackDispatcher<T extends CaseData> {
 
@@ -89,6 +88,8 @@ public class PreSubmitCallbackDispatcher<T extends CaseData> {
                     callback.getCaseDetailsBefore(),
                     callback.getEvent()
                 );
+
+                callbackForHandler.setPageId(callback.getPageId());
 
                 if (callbackHandler.canHandle(callbackStage, callbackForHandler)) {
 

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestHandlerTest.java
@@ -67,6 +67,10 @@ import uk.gov.hmcts.reform.iahearingsapi.infrastructure.clients.model.hmc.Hearin
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class UpdateHearingsRequestHandlerTest {
+
+    private static final String UPDATE_HEARING_LIST_PAGE_ID = "updateHearingList";
+    private static final String UPDATE_HEARING_DATE_PAGE_ID = "updateHearingDate";
+
     @Mock
     private Callback<AsylumCase> callback;
     @Mock
@@ -115,6 +119,7 @@ class UpdateHearingsRequestHandlerTest {
         when(asylumCase.read(HEARING_CHANNEL, DynamicList.class)).thenReturn(Optional.of(hearingChannel));
         when(hearingService.getHearing(updateHearingsCode)).thenReturn(hearingGetResponse);
         when(hearingGetResponse.getHearingDetails()).thenReturn(hearingDetails);
+        when(callback.getPageId()).thenReturn(UPDATE_HEARING_LIST_PAGE_ID);
 
         updateHearingsRequestHandler = new UpdateHearingRequestHandler(hearingService, locationRefDataService);
     }
@@ -325,6 +330,16 @@ class UpdateHearingsRequestHandlerTest {
     @Test
     void should_not_initialize_hearing_duration() {
 
+        updateHearingsRequestHandler.handle(MID_EVENT, callback);
+
+        verify(asylumCase, never()).write(eq(CHANGE_HEARING_DURATION), any());
+        verify(asylumCase, never()).write(eq(REQUEST_HEARING_LENGTH), any());
+    }
+
+    @Test
+    void should_not_run_when_not_on_hearing_list_page() {
+
+        when(callback.getPageId()).thenReturn(UPDATE_HEARING_DATE_PAGE_ID);
         updateHearingsRequestHandler.handle(MID_EVENT, callback);
 
         verify(asylumCase, never()).write(eq(CHANGE_HEARING_DURATION), any());


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8659](https://tools.hmcts.net/jira/browse/RIA-8659)


### Change description ###
- Restricted current logic that is in place for what was the only midEvent trigger for `updateHearingRequest` to the page for which it is intended


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
