### PR TITLE
RIA-8671 Make physical attendees null when no hearing channel

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/hmc/ServiceHearingValuesModel.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/hmc/ServiceHearingValuesModel.java
@@ -58,7 +58,7 @@ public class ServiceHearingValuesModel {
     @NonNull
     private PriorityType hearingPriorityType;
 
-    private int numberOfPhysicalAttendees;
+    private Integer numberOfPhysicalAttendees;
 
     private boolean hearingInWelshFlag;
 

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/PayloadUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/PayloadUtils.java
@@ -74,9 +74,18 @@ public class PayloadUtils {
         };
     }
 
-    public static int getNumberOfPhysicalAttendees(List<PartyDetailsModel> partyDetails) {
+    public static Integer getNumberOfPhysicalAttendees(List<PartyDetailsModel> partyDetails) {
 
-        int physicalAttendees = (int) partyDetails.stream()
+        List<PartyDetailsModel> partiesWithChosenChannels = partyDetails.stream()
+            .filter(party -> party.getIndividualDetails() != null
+                             && party.getIndividualDetails().getPreferredHearingChannel() != null)
+            .toList();
+
+        if (partiesWithChosenChannels.isEmpty()) {
+            return null;
+        }
+
+        int physicalAttendees = (int) partiesWithChosenChannels.stream()
             .filter(PayloadUtils::isInPersonAttendee)
             .count();
 

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/PayloadUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/PayloadUtilsTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.DEPORTATION_ORDER_OPTIONS;
@@ -40,13 +41,13 @@ public class PayloadUtilsTest {
     );
 
     @Test
-    void number_of_physical_attendees_should_be_0() {
+    void number_of_physical_attendees_should_be_null() {
 
-        assertEquals(0, PayloadUtils.getNumberOfPhysicalAttendees(partyDetailsModels));
+        assertNull(PayloadUtils.getNumberOfPhysicalAttendees(partyDetailsModels));
     }
 
     @Test
-    void number_of_physical_attendees_should_be_0_when_hearing_channel_is_on_the_papers() {
+    void number_of_physical_attendees_should_be_0_when_hearing_channel_is_not_in_person() {
 
         partyDetailsModels.get(0).setIndividualDetails(IndividualDetailsModel.builder()
                                                      .preferredHearingChannel("ONPPRS").build());


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8671](https://tools.hmcts.net/jira/browse/RIA-8671)


### Change description ###
- Made number of physical attendees be null instead of 0 if there are no channels attributed to parties' individual details


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
