### PR TITLE
RIA-8669 Make hearing update not fail if no hearings present if not yet requested

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateInterpreterDetailsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateInterpreterDetailsHandler.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iahearingsapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -45,23 +46,29 @@ public class UpdateInterpreterDetailsHandler implements PreSubmitCallbackHandler
         log.info("Updating interpreter details for case {}", callback.getCaseDetails().getId());
         try {
             HearingsGetResponse hearings = hearingService.getHearings(callback.getCaseDetails().getId());
-            CaseHearing latestSubstantiveHearing =
+            Optional<CaseHearing> latestSubstantiveHearingOptional =
                 hearings.getCaseHearings()
                     .stream()
                     .filter(hearing -> hearing.getHearingType().equals(HearingType.SUBSTANTIVE.getKey()))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException("No Substantive hearing was found."));
+                    .findFirst();
 
-            log.info("Updating hearing details for hearing {}", latestSubstantiveHearing.getHearingRequestId());
-            hearingService.updateHearing(
-                updateHearingPayloadService.createUpdateHearingPayload(
-                    asylumCase,
-                    latestSubstantiveHearing.getHearingRequestId(),
-                    ReasonCodes.OTHER.toString(),
-                    callback.getEvent()
-                ),
-                latestSubstantiveHearing.getHearingRequestId()
-            );
+            if (latestSubstantiveHearingOptional.isPresent()) {
+
+                CaseHearing latestSubstantiveHearing = latestSubstantiveHearingOptional.get();
+
+                log.info("Updating hearing details for hearing {}", latestSubstantiveHearing.getHearingRequestId());
+
+                hearingService.updateHearing(
+                    updateHearingPayloadService.createUpdateHearingPayload(
+                        asylumCase,
+                        latestSubstantiveHearing.getHearingRequestId(),
+                        ReasonCodes.OTHER.toString(),
+                        callback.getEvent()
+                    ),
+                    latestSubstantiveHearing.getHearingRequestId()
+                );
+            }
+
         } catch (Exception ex) {
             log.error(ex.getMessage());
             throw new IllegalStateException(ex.getMessage());


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8669](https://tools.hmcts.net/jira/browse/RIA-8669)


### Change description ###
- No exception thrown when executing `updateInterpreterBookingStatus` and `updateInterpreterDetails` if no substantive hearing isn't found, as they can be triggered before a hearing's been requested and they should complete successfully


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
