### PR TITLE
RIA-8659 Remove thrown exceptions if start or end date in date range missing

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestSubmit.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestSubmit.java
@@ -241,22 +241,14 @@ public class UpdateHearingRequestSubmit implements PreSubmitCallbackHandler<Asyl
                     .firstDateTimeMustBe(HearingsUtils.convertToLocalDateTimeFormat(fixedDate).toString()).build();
             }
             case "ChooseADateRange" -> {
-                String earliestDate = asylumCase.read(
-                    CHANGE_HEARING_DATE_RANGE_EARLIEST,
-                    String.class
-                ).orElseThrow(() -> new IllegalStateException(
-                    CHANGE_HEARING_DATE_RANGE_EARLIEST + " type is not present"));
+                HearingWindowModel window = HearingWindowModel.builder().build();
 
-                String latestDate = asylumCase.read(
-                    CHANGE_HEARING_DATE_RANGE_LATEST,
-                    String.class
-                ).orElseThrow(() -> new IllegalStateException(
-                    CHANGE_HEARING_DATE_RANGE_LATEST + " type is not present"));
-                yield HearingWindowModel.builder()
-                    .dateRangeStart(earliestDate)
-                    .dateRangeEnd(latestDate)
-                    .build();
+                asylumCase.read(CHANGE_HEARING_DATE_RANGE_EARLIEST, String.class)
+                    .ifPresent(window::setDateRangeStart);
+                asylumCase.read(CHANGE_HEARING_DATE_RANGE_LATEST, String.class)
+                    .ifPresent(window::setDateRangeEnd);
 
+                yield window;
             }
             default -> null;
         };

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestSubmitTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestSubmitTest.java
@@ -295,29 +295,6 @@ class UpdateHearingsRequestSubmitTest {
     }
 
     @Test
-    void should_throw_an_exception_if_no_fixed_date_is_set() {
-        asylumCase.write(CHANGE_HEARING_UPDATE_REASON, reasonCode);
-        asylumCase.write(CHANGE_HEARING_DATE_TYPE, "ChooseADateRange");
-        assertThrows(
-            IllegalStateException.class,
-            () -> updateHearingRequestSubmit.handle(ABOUT_TO_SUBMIT, callback),
-            "CHOOSE_A_DATE_RANGE_EARLIEST type is not present"
-        );
-    }
-
-    @Test
-    void should_throw_an_exception_if_no_latest_date_range_is_set() {
-        asylumCase.write(CHANGE_HEARING_UPDATE_REASON, reasonCode);
-        asylumCase.write(CHANGE_HEARING_DATE_TYPE, "ChooseADateRange");
-        asylumCase.write(CHANGE_HEARING_DATE_RANGE_EARLIEST, "2023-12-02");
-        assertThrows(
-            IllegalStateException.class,
-            () -> updateHearingRequestSubmit.handle(ABOUT_TO_SUBMIT, callback),
-            "CHOOSE_A_DATE_RANGE_LATEST type is not present"
-        );
-    }
-
-    @Test
     void should_send_an_update_of_the_hearing_duration() {
         asylumCase.write(CHANGE_HEARING_DURATION_YES_NO, YES);
         asylumCase.write(REQUEST_HEARING_LENGTH, "240");


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8659](https://tools.hmcts.net/jira/browse/RIA-8659)


### Change description ###
- Remove exception being thrown when date range to be persisted misses start or end date (validation on missing both dates exists in the previous page)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
