### PR TITLE
RIA-8741 Remove UPDATE_REQUESTED from hmcStatuses of hearings that qualify for an update

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/HearingsToDynamicListMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/HearingsToDynamicListMapper.java
@@ -34,7 +34,7 @@ public class HearingsToDynamicListMapper {
                 + " (Waiting to be listed)";
             case LISTED, AWAITING_ACTUALS ->
                 getListedAndAwaitingHearingDetailsDescription(caseHearing);
-            case UPDATE_SUBMITTED, UPDATE_REQUESTED ->
+            case UPDATE_SUBMITTED ->
                 caseHearing.getHearingTypeDescription()
                 + " (Update requested)";
             default -> null;

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/RecordAdjournmentDetailsPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/RecordAdjournmentDetailsPreparerTest.java
@@ -11,7 +11,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.RECORD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.AWAITING_LISTING;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.CANCELLATION_SUBMITTED;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.UPDATE_REQUESTED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.UPDATE_SUBMITTED;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -88,7 +88,7 @@ public class RecordAdjournmentDetailsPreparerTest {
         when(caseHearing2.getHearingRequestId()).thenReturn(CASE_HEARING_REQUEST_ID_2);
         when(caseHearing3.getHearingRequestId()).thenReturn(CASE_HEARING_REQUEST_ID_3);
         when(caseHearing1.getHmcStatus()).thenReturn(AWAITING_LISTING);
-        when(caseHearing2.getHmcStatus()).thenReturn(UPDATE_REQUESTED);
+        when(caseHearing2.getHmcStatus()).thenReturn(UPDATE_SUBMITTED);
         when(caseHearing3.getHmcStatus()).thenReturn(CANCELLATION_SUBMITTED); // disqualifies hearing for selection
         when(caseHearing1.getHearingType()).thenReturn(HEARING_TYPE);
         when(caseHearing2.getHearingType()).thenReturn(HEARING_TYPE);

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestPreparerTest.java
@@ -13,7 +13,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.AW
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.CANCELLATION_SUBMITTED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.CLOSED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.LISTED;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.UPDATE_REQUESTED;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.HmcStatus.UPDATE_SUBMITTED;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -72,7 +72,7 @@ class UpdateHearingRequestPreparerTest {
             CaseHearing.builder()
                 .hearingRequestId("2")
                 .hearingType("BFA1-SUB")
-                .hmcStatus(UPDATE_REQUESTED)
+                .hmcStatus(UPDATE_SUBMITTED)
                 .build(),
             CaseHearing.builder()
                 .hearingRequestId("3")
@@ -146,7 +146,7 @@ class UpdateHearingRequestPreparerTest {
                 .hearingRequestId("3")
                 .hearingType("BFA1-SUB")
                 .hearingRequestDateTime(LocalDateTime.of(2023, 1, 20, 0, 0))
-                .hmcStatus(UPDATE_REQUESTED)
+                .hmcStatus(UPDATE_SUBMITTED)
                 .build()
         );
         HearingsGetResponse hearingsGetResponseMock = mock(HearingsGetResponse.class);

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/HearingsToDynamicListMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/mappers/HearingsToDynamicListMapperTest.java
@@ -87,7 +87,7 @@ class HearingsToDynamicListMapperTest {
             CaseHearing.builder()
                 .hearingRequestId("3")
                 .hearingType("BFA1-SUB")
-                .hmcStatus(UPDATE_REQUESTED)
+                .hmcStatus(UPDATE_REQUESTED) // will be filtered out
                 .build(),
             CaseHearing.builder()
                 .hearingRequestId("4")
@@ -113,7 +113,7 @@ class HearingsToDynamicListMapperTest {
 
         List<Value> actualHearingValues = actual.getListItems();
         assertNotNull(actualHearingValues);
-        assertEquals(5, actualHearingValues.size());
+        assertEquals(4, actualHearingValues.size());
 
         List<String> hearingDescriptions = actualHearingValues.stream().map(Value::getLabel).toList();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8741](https://tools.hmcts.net/jira/browse/RIA-8741)


### Change description ###
- Removed UPDATE_REQUESTED from the hmcStatuses of hearings that should populate the dropdown list of updatable hearings in `recordAdjournmentDetails` and `updateHearingRequest` (UPDATE_REQUESTED and HEARING_REQUESTED are statuses of hearings that have persisted in HMC but not yet List Assist: they become UPDATE_SUBMITTED or AWAITING_LISTING when LA acknowledges the update/creation f the hearing request)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
