### PR TITLE
RIA-8757 Use requestHearingDate1 (Date) instead of requestHearingDate

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -294,8 +294,8 @@ public enum AsylumCaseFieldDefinition {
     REQUEST_HEARING_LENGTH(
         "requestHearingLength", new TypeReference<String>() {}),
 
-    REQUEST_HEARING_DATE(
-        "requestHearingDate", new TypeReference<String>(){}),
+    REQUEST_HEARING_DATE_1(
+        "requestHearingDate1", new TypeReference<String>(){}),
 
     ADDITIONAL_INSTRUCTIONS_DESCRIPTION("additionalInstructionsDescription", new TypeReference<String>(){});
 

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestHandler.java
@@ -14,12 +14,13 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_CHANNEL;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE_1;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.DECISION_WITHOUT_HEARING;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.REMOTE_HEARING;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -195,15 +196,9 @@ public class UpdateHearingRequestHandler implements PreSubmitCallbackHandler<Asy
             return false;
         }
 
-        LocalDateTime dateTime = LocalDateTime.parse(listCaseHearingDate);
-        asylumCase.write(
-            REQUEST_HEARING_DATE,
-            dateTime
-        );
-        asylumCase.write(
-            CHANGE_HEARING_DATE,
-            HearingsUtils.convertToLocalStringFormat(dateTime)
-        );
+        LocalDateTime dateTime =  LocalDateTime.parse(listCaseHearingDate);
+        asylumCase.write(REQUEST_HEARING_DATE_1, dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        asylumCase.write(CHANGE_HEARING_DATE, HearingsUtils.convertToLocalStringFormat(dateTime));
 
         return true;
     }
@@ -215,7 +210,7 @@ public class UpdateHearingRequestHandler implements PreSubmitCallbackHandler<Asy
 
         if (hearingWindow.getFirstDateTimeMustBe() != null) {
             LocalDateTime firstDateTime = LocalDateTime.parse(hearingWindow.getFirstDateTimeMustBe());
-            asylumCase.write(REQUEST_HEARING_DATE, firstDateTime);
+            asylumCase.write(REQUEST_HEARING_DATE_1, firstDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
             String dateStr = "Date to be fixed: " + HearingsUtils.convertToLocalStringFormat(firstDateTime);
             asylumCase.write(CHANGE_HEARING_DATE, dateStr);
 

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestSubmit.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestSubmit.java
@@ -19,7 +19,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_UPDATE_HEARING_REQUIRED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_CHANNEL;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE_1;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.getValueByEpimsId;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.hmc.ListAssistCaseStatus.AWAITING_LISTING;
@@ -233,9 +233,9 @@ public class UpdateHearingRequestSubmit implements PreSubmitCallbackHandler<Asyl
         return switch (hearingDateChangeType) {
             case "DateToBeFixed" -> {
                 String fixedDate = asylumCase.read(
-                    REQUEST_HEARING_DATE,
+                    REQUEST_HEARING_DATE_1,
                     String.class
-                ).orElseThrow(() -> new IllegalStateException(REQUEST_HEARING_DATE + " type is not present"));
+                ).orElseThrow(() -> new IllegalStateException(REQUEST_HEARING_DATE_1 + " type is not present"));
 
                 yield HearingWindowModel.builder()
                     .firstDateTimeMustBe(HearingsUtils.convertToLocalDateTimeFormat(fixedDate).toString()).build();

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestHandlerTest.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_CHANNEL;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE_1;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.BIRMINGHAM;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.DECISION_WITHOUT_HEARING;
@@ -33,7 +33,6 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.END_AP
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUEST;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -90,8 +89,6 @@ class UpdateHearingsRequestHandlerTest {
     private ArgumentCaptor<DynamicList> dynamicListArgumentCaptor;
     @Captor
     private ArgumentCaptor<String> stringArgumentCaptor;
-    @Captor
-    private ArgumentCaptor<LocalDateTime> localDateTimeArgumentCaptor;
 
     private DynamicList hearingLocation;
     private DynamicList hearingChannel;
@@ -145,7 +142,7 @@ class UpdateHearingsRequestHandlerTest {
         verify(asylumCase, never()).write(eq(CHANGE_HEARING_DURATION), any());
         verify(asylumCase, never()).write(eq(REQUEST_HEARING_LENGTH), any());
         verify(asylumCase, never()).write(eq(CHANGE_HEARING_DATE), any());
-        verify(asylumCase, never()).write(eq(REQUEST_HEARING_DATE), any());
+        verify(asylumCase, never()).write(eq(REQUEST_HEARING_DATE_1), any());
     }
 
     @Test
@@ -250,9 +247,9 @@ class UpdateHearingsRequestHandlerTest {
         updateHearingsRequestHandler.handle(MID_EVENT, callback);
 
         verify(asylumCase).write(eq(CHANGE_HEARING_DATE), stringArgumentCaptor.capture());
-        verify(asylumCase).write(eq(REQUEST_HEARING_DATE), localDateTimeArgumentCaptor.capture());
-        assertEquals("20 January 2023", stringArgumentCaptor.getValue());
-        assertEquals("2023-01-20T10:30", localDateTimeArgumentCaptor.getValue().toString());
+        verify(asylumCase).write(eq(REQUEST_HEARING_DATE_1), stringArgumentCaptor.capture());
+        assertEquals("20 January 2023", stringArgumentCaptor.getAllValues().get(0));
+        assertEquals("2023-01-20", stringArgumentCaptor.getAllValues().get(1));
     }
 
     @Test
@@ -275,9 +272,9 @@ class UpdateHearingsRequestHandlerTest {
         updateHearingsRequestHandler.handle(MID_EVENT, callback);
 
         verify(asylumCase).write(eq(CHANGE_HEARING_DATE), stringArgumentCaptor.capture());
-        verify(asylumCase).write(eq(REQUEST_HEARING_DATE), localDateTimeArgumentCaptor.capture());
-        assertEquals("Date to be fixed: 20 January 2023", stringArgumentCaptor.getValue());
-        assertEquals("2023-01-20T10:30", localDateTimeArgumentCaptor.getValue().toString());
+        verify(asylumCase).write(eq(REQUEST_HEARING_DATE_1), stringArgumentCaptor.capture());
+        assertEquals("Date to be fixed: 20 January 2023", stringArgumentCaptor.getAllValues().get(0));
+        assertEquals("2023-01-20", stringArgumentCaptor.getAllValues().get(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestSubmitTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestSubmitTest.java
@@ -27,7 +27,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_UPDATE_HEARING_REQUIRED;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_CHANNEL;
-import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_DATE_1;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.REQUEST_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.NEWCASTLE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUEST;
@@ -193,7 +193,7 @@ class UpdateHearingsRequestSubmitTest {
     void should_send_an_update_of_the_hearing_window_date_to_be_fixed() {
         asylumCase.write(CHANGE_HEARING_DATE_YES_NO, YES);
         asylumCase.write(CHANGE_HEARING_DATE_TYPE, "DateToBeFixed");
-        asylumCase.write(REQUEST_HEARING_DATE, "2023-12-02T00:00:00.000");
+        asylumCase.write(REQUEST_HEARING_DATE_1, "2023-12-02T00:00:00.000");
         asylumCase.write(CHANGE_HEARING_UPDATE_REASON, reasonCode);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse = updateHearingRequestSubmit.handle(

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadServiceTest.java
@@ -6,6 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DURATION_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_LOCATION_YES_NO;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_TYPE_YES_NO;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.HEARING_LOCATION;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldDefinition.NEXT_HEARING_VENUE;
@@ -15,6 +19,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.DE
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.HearingCentre.LEEDS_MAGS;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUEST;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.Event.UPDATE_INTERPRETER_DETAILS;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.util.List;
 import java.util.Optional;
@@ -142,6 +147,7 @@ class UpdateHearingPayloadServiceTest {
     @Test
     void should_create_an_update_hearing_request_with_hearing_channels_set_to_on_the_papers() {
 
+        when(asylumCase.read(CHANGE_HEARING_TYPE_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YES));
         when(caseDataMapper.getHearingChannels(asylumCase,
                                                persistedHearing.getHearingDetails(),
                                                UPDATE_HEARING_REQUEST))
@@ -206,6 +212,7 @@ class UpdateHearingPayloadServiceTest {
     void should_create_an_update_hearing_request_with_new_duration() {
         Integer duration = 240;
         when(updateHearingPayloadService.getHearingDuration(asylumCase, UPDATE_HEARING_REQUEST)).thenReturn(duration);
+        when(asylumCase.read(CHANGE_HEARING_DURATION_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YES));
 
         UpdateHearingRequest updateHearingRequest = updateHearingPayloadService.createUpdateHearingPayload(
             asylumCase,
@@ -227,6 +234,8 @@ class UpdateHearingPayloadServiceTest {
 
     @Test
     void should_create_an_update_hearing_request_with_first_available_date() {
+        when(asylumCase.read(CHANGE_HEARING_DATE_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YES));
+
         UpdateHearingRequest updateHearingRequest = updateHearingPayloadService.createUpdateHearingPayload(
             asylumCase,
             updateHearingsCode,
@@ -243,10 +252,13 @@ class UpdateHearingPayloadServiceTest {
 
     @Test
     void should_create_an_update_hearing_request_with_date_fixed() {
+        when(asylumCase.read(CHANGE_HEARING_DATE_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YES));
+
         HearingWindowModel hearingWindow = HearingWindowModel
             .builder()
             .dateRangeStart("2023-12-02T00:00")
             .build();
+
         UpdateHearingRequest updateHearingRequest = updateHearingPayloadService.createUpdateHearingPayload(
             asylumCase,
             updateHearingsCode,
@@ -263,11 +275,14 @@ class UpdateHearingPayloadServiceTest {
 
     @Test
     void should_create_an_update_hearing_request_with_date_range() {
+        when(asylumCase.read(CHANGE_HEARING_DATE_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YES));
+
         HearingWindowModel hearingWindow = HearingWindowModel
             .builder()
             .dateRangeStart("2023-03-10")
             .dateRangeEnd("2023-03-30")
             .build();
+
         UpdateHearingRequest updateHearingRequest = updateHearingPayloadService.createUpdateHearingPayload(
             asylumCase,
             updateHearingsCode,
@@ -479,6 +494,8 @@ class UpdateHearingPayloadServiceTest {
     void should_return_requested_update_hearing_value_when_the_event_is_update_hearing_request() {
         when(asylumCase.read(HEARING_LOCATION, DynamicList.class)).thenReturn(
             Optional.of(new DynamicList("783803")));
+        when(asylumCase.read(CHANGE_HEARING_LOCATION_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(CHANGE_HEARING_DURATION_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YES));
         when(updateHearingPayloadService.getHearingDuration(asylumCase, UPDATE_HEARING_REQUEST)).thenReturn(90);
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8757](https://tools.hmcts.net/jira/browse/RIA-8757)


### Change description ###
- Swapped `requestHearingDate` for `requestHearingDate1`, which uses Date instead of DateTime
- Update only selected fields during 'updateHearingRequest' event ([RIA-8805](https://tools.hmcts.net/jira/browse/RIA-8805))


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
