### PR TITLE
RIA-8757 fix firstDateTimeMustBe

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestSubmit.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingRequestSubmit.java
@@ -238,7 +238,8 @@ public class UpdateHearingRequestSubmit implements PreSubmitCallbackHandler<Asyl
                 ).orElseThrow(() -> new IllegalStateException(REQUEST_HEARING_DATE_1 + " type is not present"));
 
                 yield HearingWindowModel.builder()
-                    .firstDateTimeMustBe(HearingsUtils.convertToLocalDateTimeFormat(fixedDate).toString()).build();
+                    .firstDateTimeMustBe(HearingsUtils.convertToLocalDateTimeFormat(fixedDate)
+                                             .withHour(16).toString()).build();
             }
             case "ChooseADateRange" -> {
                 HearingWindowModel window = HearingWindowModel.builder().build();

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/HearingsUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/HearingsUtils.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iahearingsapi.domain.utils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -28,8 +29,8 @@ public final class HearingsUtils {
     }
 
     public static LocalDateTime convertToLocalDateTimeFormat(String date) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(YYYY_MM_DD_HH_mm_ss_sss);
-        return LocalDateTime.parse(date, formatter);
+        LocalDate localDate = LocalDate.parse(date);
+        return LocalDateTime.of(localDate, LocalTime.of(0, 0, 0));
     }
 
     public static LocalDateTime convertFromUTC(LocalDateTime utcDate) {

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestSubmitTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/handlers/presubmit/UpdateHearingsRequestSubmitTest.java
@@ -193,7 +193,7 @@ class UpdateHearingsRequestSubmitTest {
     void should_send_an_update_of_the_hearing_window_date_to_be_fixed() {
         asylumCase.write(CHANGE_HEARING_DATE_YES_NO, YES);
         asylumCase.write(CHANGE_HEARING_DATE_TYPE, "DateToBeFixed");
-        asylumCase.write(REQUEST_HEARING_DATE_1, "2023-12-02T00:00:00.000");
+        asylumCase.write(REQUEST_HEARING_DATE_1, "2023-12-02");
         asylumCase.write(CHANGE_HEARING_UPDATE_REASON, reasonCode);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse = updateHearingRequestSubmit.handle(
@@ -204,7 +204,7 @@ class UpdateHearingsRequestSubmitTest {
         verify(hearingService, times(1)).updateHearing(any(), any());
         HearingWindowModel newHearingWindow = HearingWindowModel
             .builder()
-            .firstDateTimeMustBe("2023-12-02T00:00")
+            .firstDateTimeMustBe("2023-12-02T16:00")
             .build();
 
         verify(updateHearingPayloadService, times(1)).createUpdateHearingPayload(

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/HearingsUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/HearingsUtilsTest.java
@@ -1,10 +1,9 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.utils;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDateTime;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class HearingsUtilsTest {
 
@@ -28,10 +27,10 @@ public class HearingsUtilsTest {
 
     @Test
     void testConvertToLocalDateTimeFormat() {
-        String dateTimeStr = "2023-10-06T12:00:00.000";
+        String dateStr = "2023-10-06";
 
-        LocalDateTime localDateTime = HearingsUtils.convertToLocalDateTimeFormat(dateTimeStr);
+        LocalDateTime localDateTime = HearingsUtils.convertToLocalDateTimeFormat(dateStr);
 
-        assertEquals(LocalDateTime.of(2023, 10, 6, 12, 0, 0), localDateTime);
+        assertEquals(LocalDateTime.of(2023, 10, 6, 0, 0, 0), localDateTime);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8757](https://tools.hmcts.net/jira/browse/RIA-8757)


### Change description ###
- Fix date time compatibility problem between dates / dateTimes for `requestHearingDate1` field


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
