### PR TITLE
RIA-8821 Use hearingCentreRefData to populate caseManagementLocationCode in payload

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/entities/BailCaseFieldDefinition.java
@@ -152,7 +152,9 @@ public enum BailCaseFieldDefinition {
     APPLICANT_HAS_MOBILE(
         "applicantHasMobile", new TypeReference<YesOrNo>(){}),
     APPLICANT_MOBILE_NUMBER(
-        "applicantMobileNumber1", new TypeReference<String>(){}),;
+        "applicantMobileNumber1", new TypeReference<String>(){}),
+    HEARING_CENTRE_REF_DATA(
+        "hearingCentreRefData", new TypeReference<DynamicList>(){});
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/ServiceHearingValuesProvider.java
@@ -6,6 +6,7 @@ import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.AsylumCaseFieldD
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.CASE_NAME_HMCTS_INTERNAL;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.Facilities.IAC_TYPE_C_CONFERENCE_EQUIPMENT;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.utils.HearingsUtils.getEpimsId;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.utils.PayloadUtils.getCaseCategoriesValue;
 import static uk.gov.hmcts.reform.iahearingsapi.domain.utils.PayloadUtils.getNumberOfPhysicalAttendees;
 
@@ -53,6 +54,7 @@ public class ServiceHearingValuesProvider {
     private static final String LOCATION_OF_SCREEN_FLOW_FILE_APPEALS = "classpath:appealsScreenFlow.json";
     private static final String LOCATION_OF_SCREEN_FLOW_FILE_BAILS = "classpath:bailsScreenFlow.json";
     private static final String TRIBUNAL_JUDGE = "84";
+    private static final String BAILS_LOCATION_REF_DATA_FEATURE = "bails-location-reference-data";
 
     private final CaseDataToServiceHearingValuesMapper caseDataMapper;
     private final BailCaseDataToServiceHearingValuesMapper bailCaseDataMapper;
@@ -61,6 +63,7 @@ public class ServiceHearingValuesProvider {
     private final PartyDetailsMapper partyDetailsMapper;
     private final ListingCommentsMapper listingCommentsMapper;
     private final ResourceLoader resourceLoader;
+    private final FeatureToggler featureToggler;
     @Value("${xui.api.baseUrl}")
     private String baseUrl;
 
@@ -165,7 +168,7 @@ public class ServiceHearingValuesProvider {
             .caseCategories(getBailCaseCategoriesValue())
             .caseDeepLink(baseUrl.concat(caseDataMapper.getCaseDeepLink(caseReference)))
             .externalCaseReference(bailCaseDataMapper.getExternalCaseReference(bailCase))
-            .caseManagementLocationCode(bailCaseDataMapper.getCaseManagementLocationCode(bailCase))
+            .caseManagementLocationCode(getCaseManagementLocationCode(bailCase))
             .autoListFlag(false)
             .caseSlaStartDate(bailCaseDataMapper.getCaseSlaStartDate(bailCase))
             .duration(Integer.parseInt(listCaseHearingLength))
@@ -250,5 +253,11 @@ public class ServiceHearingValuesProvider {
 
     private List<PartyDetailsModel> getPartyDetails(BailCase bailCase) {
         return partyDetailsMapper.mapBailPartyDetails(bailCase, bailCaseFlagsMapper, bailCaseDataMapper);
+    }
+
+    private String getCaseManagementLocationCode(BailCase bailCase) {
+        return featureToggler.getValue(BAILS_LOCATION_REF_DATA_FEATURE, false)
+            ? getEpimsId(bailCase)
+            : bailCaseDataMapper.getCaseManagementLocationCode(bailCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/HearingsUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/HearingsUtils.java
@@ -1,11 +1,15 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.utils;
 
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.HEARING_CENTRE_REF_DATA;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.DynamicList;
 
 public final class HearingsUtils {
 
@@ -37,5 +41,11 @@ public final class HearingsUtils {
         ZonedDateTime utcZonedDateTime = utcDate.atZone(ZoneId.of("UTC"));
         ZonedDateTime ukZonedDateTime = utcZonedDateTime.withZoneSameInstant(ZoneId.of("Europe/London"));
         return ukZonedDateTime.toLocalDateTime();
+    }
+
+    public static String getEpimsId(BailCase bailCase) {
+        return bailCase.read(HEARING_CENTRE_REF_DATA, DynamicList.class)
+            .map(dynamicList -> dynamicList.getValue().getCode())
+            .orElse("");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/HearingsUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahearingsapi/domain/utils/HearingsUtilsTest.java
@@ -1,11 +1,25 @@
 package uk.gov.hmcts.reform.iahearingsapi.domain.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCaseFieldDefinition.HEARING_CENTRE_REF_DATA;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.DynamicList;
+import uk.gov.hmcts.reform.iahearingsapi.domain.entities.Value;
 
+@ExtendWith(MockitoExtension.class)
 public class HearingsUtilsTest {
+
+    @Mock
+    BailCase bailCase;
 
     @Test
     void testConvertToLocalStringFormat() {
@@ -32,5 +46,21 @@ public class HearingsUtilsTest {
         LocalDateTime localDateTime = HearingsUtils.convertToLocalDateTimeFormat(dateStr);
 
         assertEquals(LocalDateTime.of(2023, 10, 6, 0, 0, 0), localDateTime);
+    }
+
+    @Test
+    void shouldGetEpimsIdFromHearingCentreRefData() {
+        final String glasgow = "366559";
+        when(bailCase.read(HEARING_CENTRE_REF_DATA, DynamicList.class))
+            .thenReturn(
+                Optional.of(
+                    new DynamicList(
+                        new Value(glasgow, glasgow),
+                        List.of(new Value(glasgow, glasgow))
+                    )
+                )
+            );
+
+        assertEquals(glasgow, HearingsUtils.getEpimsId(bailCase));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8821](https://tools.hmcts.net/jira/browse/RIA-8821)


### Change description ###
- Use `hearingCentreRefData` to populate caseManagementLocationCode in the hearing request payload when the LaunchDarkly location ref data feature is enabled


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
