### PR TITLE
RIA-9146 - Fix for HMC failed validation when (non null) empty hearing window object is passed in payload

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahearingsapi/domain/service/UpdateHearingPayloadService.java
@@ -240,6 +240,10 @@ public class UpdateHearingPayloadService extends CreateHearingPayloadService {
                 .map(changeDate -> equalsIgnoreCase(YES.toString(), changeDate)).orElse(false);
             if (updateHearingDate) {
                 hearingDetails.setHearingWindow(hearingsDetailsUpdate.getHearingWindow());
+            } else {
+                if (hearingDetails.getHearingWindow().allNull()) {
+                    hearingDetails.setHearingWindow(null);
+                }
             }
         } else {
             hearingDetails.setHearingChannels(hearingsDetailsUpdate.getHearingChannels());


### PR DESCRIPTION


**Before creating a pull request make sure that:**

- [z ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [z ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-9146


### Change description ###
Fix for HMC failed validation when (non null) empty hearing window object is passed in payload


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
