### PR TITLE
DIAC-590 update spring-security packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -309,6 +309,13 @@ ext {
         entry 'logback-core'
       }
 
+      dependencySet(group: 'org.springframework.security', version: '1.1.1') {
+        entry 'spring-security-rsa'
+      }
+      dependencySet(group: 'org.springframework.security', version: '5.8.11') {
+        entry 'spring-security-oauth2-client'
+      }
+
     }
   }}
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,7 +2,5 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <cve>CVE-2023-36052</cve>
-    <cve>CVE-2023-33202</cve>
-    <cve>CVE-2023-1370</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DIAC-590](https://tools.hmcts.net/jira/browse/DIAC-590)

### Change description ###
add dependency set to org.springframework.security:spring-security-rsa:1.1.1 fixing [CVE-2023-33202](https://github.com/advisories/GHSA-wjxj-5m7g-mg7q)
add dependency set to org.springframework.security:spring-security-oauth2-client:5.8.11 fixing [CVE-2023-1370](https://github.com/advisories/GHSA-493p-pfq6-5258)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
