### PR TITLE
DIAC-2168 - Bump Application Insights agent version to 3.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG APP_INSIGHTS_AGENT_VERSION=3.4.13
+ARG APP_INSIGHTS_AGENT_VERSION=3.7.3
 FROM hmctsprod.azurecr.io/base/java:21-distroless
 
 COPY lib/applicationinsights.json /opt/app/


### PR DESCRIPTION
Aligns with the version used by ia-case-api and other IA services for consistent telemetry collection across the platform.